### PR TITLE
added email reporting python script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
-**import_monitoring.txt
+import_monitoring.html
 **taxon_dump.sql
 tests/test_images/test_image.jpg~
 **/test_hexdump.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+
+**import_monitoring.txt
+**taxon_dump.sql
 tests/test_images/test_image.jpg~
 **/test_hexdump.txt
 **/test_image.jpg_original

--- a/botany_importer.py
+++ b/botany_importer.py
@@ -7,7 +7,10 @@ import os
 import re
 import logging
 from dir_tools import DirTools
-
+from uuid import uuid4
+from time_utils import get_pst_time_now_string
+from monitoring_tools import create_monitoring_report
+from gen_import_utils import generate_token
 # I:\botany\PLANT FAMILIES
 #
 # I:\botany\TYPE IMAGES
@@ -40,7 +43,19 @@ class BotanyImporter(Importer):
         #     pickle.dump(self.barcode_map, outfile)
         # else:
         #     self.barcode_map = pickle.load(open(FILENAME, "rb"))
+
+        if config == botany_importer_config:
+            self.batch_size = len(paths)
+            self.batch_md5 = generate_token(timestamp=get_pst_time_now_string(), filename=uuid4())
+
         self.process_loaded_files()
+
+        if config == botany_importer_config:
+            create_monitoring_report(batch_size=self.batch_size, batch_md5=self.batch_md5,
+                                     agent=botany_importer_config.AGENT_ID,
+                                     config_file=botany_importer_config)
+
+
 
     def process_loaded_files(self):
         for barcode in self.barcode_map.keys():

--- a/botany_importer.py
+++ b/botany_importer.py
@@ -9,7 +9,7 @@ import logging
 from dir_tools import DirTools
 from uuid import uuid4
 from time_utils import get_pst_time_now_string
-from monitoring_tools import create_monitoring_report
+from monitoring_tools import create_monitoring_report, send_out_emails
 from gen_import_utils import generate_token
 # I:\botany\PLANT FAMILIES
 #
@@ -45,15 +45,17 @@ class BotanyImporter(Importer):
         #     self.barcode_map = pickle.load(open(FILENAME, "rb"))
 
         if config == botany_importer_config:
-            self.batch_size = len(paths)
+            self.batch_size = len(self.barcode_map.keys())
             self.batch_md5 = generate_token(timestamp=get_pst_time_now_string(), filename=uuid4())
+            create_monitoring_report(num_barcodes=self.batch_size, batch_md5=self.batch_md5,
+                                     agent=botany_importer_config.AGENT_ID,
+                                     config_file=botany_importer_config)
 
         self.process_loaded_files()
 
         if config == botany_importer_config:
-            create_monitoring_report(batch_size=self.batch_size, batch_md5=self.batch_md5,
-                                     agent=botany_importer_config.AGENT_ID,
-                                     config_file=botany_importer_config)
+            send_out_emails(f"BOT_Batch: {get_pst_time_now_string()}", config=botany_importer_config)
+
 
 
 

--- a/botany_importer.py
+++ b/botany_importer.py
@@ -30,6 +30,8 @@ class BotanyImporter(Importer):
 
         self.logger.debug("Botany import mode")
 
+
+
         # FILENAME = "bio_importer.bin"
         # if not os.path.exists(FILENAME):
         for cur_dir in paths:

--- a/botany_importer.py
+++ b/botany_importer.py
@@ -9,7 +9,7 @@ import logging
 from dir_tools import DirTools
 from uuid import uuid4
 from time_utils import get_pst_time_now_string
-from monitoring_tools import create_monitoring_report, send_out_emails
+from monitoring_tools import create_monitoring_report, send_monitoring_report
 from gen_import_utils import generate_token
 # I:\botany\PLANT FAMILIES
 #
@@ -54,7 +54,7 @@ class BotanyImporter(Importer):
         self.process_loaded_files()
 
         if config == botany_importer_config:
-            send_out_emails(f"BOT_Batch: {get_pst_time_now_string()}", config=botany_importer_config)
+            send_monitoring_report(subject=f"BOT_Batch: {get_pst_time_now_string()}", config=botany_importer_config)
 
 
 

--- a/botany_importer_config.template.py
+++ b/botany_importer_config.template.py
@@ -3,8 +3,8 @@ SPECIFY_DATABASE_PORT = 3306
 SPECIFY_DATABASE = 'redacted'
 USER = 'redacted'
 PASSWORD = 'redacted'
-
-
+# agent id in database
+AGENT_ID = 123456
 import os
 sla = os.path.sep
 COLLECTION_NAME = 'Botany'
@@ -17,7 +17,7 @@ BOTANY_SCAN_FOLDERS = [f'botany{sla}TYPE IMAGES',
 
 
 # list of custom summary terms to add to monitoring email template
-SUMMARY_TERMS = ["term1", "term2"]
+SUMMARY_TERMS = ['additional terms to summarize']
 
-mailing_list = ['list of email addresses']
+mailing_list = ['mdelaroca@calacademy.org']
 

--- a/botany_importer_config.template.py
+++ b/botany_importer_config.template.py
@@ -16,4 +16,8 @@ BOTANY_SCAN_FOLDERS = [f'botany{sla}TYPE IMAGES',
                        f'botany{sla}PLANT FAMILIES']
 
 
+# list of custom summary terms to add to monitoring email template
+SUMMARY_TERMS = ["term1", "term2"]
+
+mailing_list = ['list of email addresses']
 

--- a/botany_importer_config.template.py
+++ b/botany_importer_config.template.py
@@ -16,8 +16,16 @@ BOTANY_SCAN_FOLDERS = [f'botany{sla}TYPE IMAGES',
                        f'botany{sla}PLANT FAMILIES']
 
 
-# list of custom summary terms to add to monitoring email template
-SUMMARY_TERMS = ['additional terms to summarize']
+# config fields for monitoring emails
+SUMMARY_TERMS = ['list of summary stats to add ']
 
-mailing_list = ['mdelaroca@calacademy.org']
+SUMMARY_IMG = ['list of graph/image filepaths to add to report']
+
+mailing_list = ['list of emails to send report to']
+
+#smpty terms
+smtp_user = "your email"
+smtp_server = "smtp.gmail.com"
+smtp_port = 587
+smtp_password = "your app password"
 

--- a/client_tools.py
+++ b/client_tools.py
@@ -3,6 +3,7 @@ import argparse
 import botany_importer_config
 import picturae_config
 from picturae_import_utils import get_max_subdirectory_date
+from monitoring_tools import clear_txt
 import os
 import logging
 import collection_definitions
@@ -14,7 +15,6 @@ from ichthyology_importer import IchthyologyImporter
 from image_client import ImageClient
 from botany_purger import BotanyPurger
 from PIC_undo_batch import PicturaeUndoBatch
-
 args = None
 logger = None
 
@@ -54,7 +54,8 @@ def parse_command_line():
 
 
 def main(args):
-
+    # clearing import logs
+    clear_txt("import_monitoring.txt")
     if args.subcommand == 'search':
         image_client = ImageClient()
     elif args.subcommand == 'import':
@@ -121,6 +122,7 @@ def setup_logging(verbosity: int):
     logger.addHandler(console_handler)
 
     # with this pattern, it's rarely necessary to propagate the error up to parent
+
     logger.propagate = False
 
     if verbosity == 0:

--- a/client_tools.py
+++ b/client_tools.py
@@ -67,7 +67,6 @@ def main(args):
                                           botany_importer_config.BOTANY_PREFIX,
                                           cur_dir))
                 print(f"Scanning: {cur_dir}")
-            print(paths)
             BotanyImporter(paths=paths, config=botany_importer_config)
         elif args.collection == 'Botany_PIC':
             date_override = args.date
@@ -114,7 +113,7 @@ def setup_logging(verbosity: int):
 
     """
     global logger
-    print("setting up logging...")
+    logger.info("setting up logging...")
     logger = logging.getLogger('Client')
     console_handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter("%(name)s — %(levelname)s — %(funcName)s:%(lineno)d - %(message)s")

--- a/client_tools.py
+++ b/client_tools.py
@@ -2,7 +2,7 @@
 import argparse
 import botany_importer_config
 import picturae_config
-from picturae_import_utils import get_max_subdirectory_date
+from gen_import_utils import get_max_subdirectory_date
 from monitoring_tools import clear_txt
 import os
 import logging
@@ -55,7 +55,7 @@ def parse_command_line():
 
 def main(args):
     # clearing import logs
-    clear_txt("import_monitoring.txt")
+    clear_txt("import_monitoring.html")
     if args.subcommand == 'search':
         image_client = ImageClient()
     elif args.subcommand == 'import':
@@ -67,7 +67,7 @@ def main(args):
                                           botany_importer_config.BOTANY_PREFIX,
                                           cur_dir))
                 print(f"Scanning: {cur_dir}")
-
+            print(paths)
             BotanyImporter(paths=paths, config=botany_importer_config)
         elif args.collection == 'Botany_PIC':
             date_override = args.date

--- a/gen_import_utils.py
+++ b/gen_import_utils.py
@@ -9,7 +9,8 @@ import pandas as pd
 import os
 from PIL import Image
 import re
-
+import hmac
+import settings
 
 # import list tools
 
@@ -97,3 +98,19 @@ def cont_prompter():
             sys.exit("Script terminated by user.")
         else:
             print("Invalid input. Please enter 'y' or 'n'.")
+
+def generate_token(timestamp, filename):
+    """Generate the auth token for the given filename and timestamp.
+    This is for comparing to the client submited token.
+    args:
+        timestamp: starting timestamp of upload batch
+        file_name: the name of the datafile that was uploaded
+    """
+    timestamp = str(timestamp)
+    if timestamp is None:
+        print(f"Missing timestamp; token generation failure.")
+    if filename is None:
+        print(f"Missing filename, token generation failure.")
+    mac = hmac.new(settings.KEY.encode(), timestamp.encode() + filename.encode(), digestmod='md5')
+    print(f"Generated new token for {filename} at {timestamp}.")
+    return ':'.join((mac.hexdigest(), timestamp))

--- a/ich_importer_config.template.py
+++ b/ich_importer_config.template.py
@@ -14,8 +14,15 @@ IMAGE_DIRECTORY_PREFIX = "/letter_drives/n_drive"
 SCAN_DIR = f'ichthyology{sla}images{sla}'
 ICH_SCAN_FOLDERS = ['AutomaticSpecifyImport']
 
+# config fields for monitoring emails
+SUMMARY_TERMS = ['list of summary stats to add ']
 
-# list of custom summary terms to add to monitoring email template
-SUMMARY_TERMS = ["term1", "term2"]
+SUMMARY_IMG = ['list of graph/image filepaths to add to report']
 
-mailing_list = ['list of email addresses']
+mailing_list = ['list of emails to send report to']
+
+#smpty terms
+smtp_user = "your email"
+smtp_server = "smtp.gmail.com"
+smtp_port = 587
+smtp_password = "your app password"

--- a/ich_importer_config.template.py
+++ b/ich_importer_config.template.py
@@ -6,6 +6,8 @@ SPECIFY_DATABASE = 'casich'
 USER = 'redacrted'
 PASSWORD = 'redacted'
 COLLECTION_NAME='Ichthyology'
+# agent id number in db
+AGENT_ID = 123456
 sla = os.path.sep
 # final directory will be prefix + scan dir  and then iterate over all ICH_SCAN_FOLDERS
 IMAGE_DIRECTORY_PREFIX = "/letter_drives/n_drive"

--- a/ich_importer_config.template.py
+++ b/ich_importer_config.template.py
@@ -12,3 +12,8 @@ IMAGE_DIRECTORY_PREFIX = "/letter_drives/n_drive"
 SCAN_DIR = f'ichthyology{sla}images{sla}'
 ICH_SCAN_FOLDERS = ['AutomaticSpecifyImport']
 
+
+# list of custom summary terms to add to monitoring email template
+SUMMARY_TERMS = ["term1", "term2"]
+
+mailing_list = ['list of email addresses']

--- a/ichthyology_importer.py
+++ b/ichthyology_importer.py
@@ -5,7 +5,7 @@ import re
 import logging
 from dir_tools import DirTools
 from uuid import uuid4
-from monitoring_tools import create_monitoring_report
+from monitoring_tools import create_monitoring_report, send_out_emails
 from time_utils import get_pst_time_now_string
 from gen_import_utils import generate_token
 
@@ -33,15 +33,18 @@ class IchthyologyImporter(Importer):
         # pickle.dump(ichthyology_importer.catalog_number_map, outfile)
         # else:
         #     ichthyology_importer.catalog_number_map = pickle.load(open(FILENAME, "rb"))
-        self.batch_size = 0
+        self.barcodes_processed = len(self.catalog_number_map.keys())
 
         # uuid is a placeholder for now
         self.batch_md5 = generate_token(timestamp=get_pst_time_now_string(), filename=uuid4())
 
+        create_monitoring_report(num_barcodes=self.barcodes_processed, batch_md5=self.batch_md5,
+                                 agent=ich_importer_config.AGENT_ID,
+                                 config_file=ich_importer_config)
+
         self.process_loaded_files()
 
-        create_monitoring_report(batch_size=self.batch_size, batch_md5=self.batch_md5,
-                                 agent=ich_importer_config.AGENT_ID, config_file=ich_importer_config)
+        send_out_emails(subject=f"ICH_Batch:{get_pst_time_now_string()}", config=ich_importer_config)
 
     def get_catalog_number(self, filename):
         #  the institution and collection codes before the catalog number

--- a/ichthyology_importer.py
+++ b/ichthyology_importer.py
@@ -5,7 +5,7 @@ import re
 import logging
 from dir_tools import DirTools
 from uuid import uuid4
-from monitoring_tools import create_monitoring_report, send_out_emails
+from monitoring_tools import create_monitoring_report, send_monitoring_report
 from time_utils import get_pst_time_now_string
 from gen_import_utils import generate_token
 
@@ -44,7 +44,7 @@ class IchthyologyImporter(Importer):
 
         self.process_loaded_files()
 
-        send_out_emails(subject=f"ICH_Batch:{get_pst_time_now_string()}", config=ich_importer_config)
+        send_monitoring_report(subject=f"ICH_Batch:{get_pst_time_now_string()}", config=ich_importer_config)
 
     def get_catalog_number(self, filename):
         #  the institution and collection codes before the catalog number

--- a/image_client.py
+++ b/image_client.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 import os
 from monitoring_tools import add_imagepath_to_txt
+from string_utils import remove_non_numerics
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S%z"
 
 
@@ -113,7 +114,8 @@ class ImageClient:
         r = requests.post(url, files=files, data=data)
         if r.status_code != 200:
             print(f"Image upload aborted: {r.status_code}:{r.text}")
-            add_imagepath_to_txt(local_filename, failure=True)
+            add_imagepath_to_txt(local_filename, barcode=remove_non_numerics(os.path.basename(local_filename)),
+                                 success=False)
             raise UploadFailureException
         else:
             params = {
@@ -127,7 +129,9 @@ class ImageClient:
             url = r.text
             assert r.status_code == 200
             logging.info(f"Uploaded: {local_filename},{attach_loc},{url}")
-            add_imagepath_to_txt(local_filename)
+            print("adding to image")
+            add_imagepath_to_txt(path=local_filename, barcode=remove_non_numerics(os.path.basename(local_filename)),
+                                 success=True)
 
         logging.debug("Upload to file server complete")
 

--- a/image_client.py
+++ b/image_client.py
@@ -3,11 +3,10 @@ import time
 import sys
 import server_host_settings
 from uuid import uuid4
-from os.path import splitext
 import datetime
 import logging
 import os
-
+from monitoring_tools import add_imagepath_to_txt
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S%z"
 
 
@@ -114,6 +113,7 @@ class ImageClient:
         r = requests.post(url, files=files, data=data)
         if r.status_code != 200:
             print(f"Image upload aborted: {r.status_code}:{r.text}")
+            add_imagepath_to_txt(local_filename, failure=True)
             raise UploadFailureException
         else:
             params = {
@@ -126,9 +126,11 @@ class ImageClient:
             r = requests.get(self.build_url("getfileref"), params=params)
             url = r.text
             assert r.status_code == 200
+            logging.info(f"Uploaded: {local_filename},{attach_loc},{url}")
+            add_imagepath_to_txt(local_filename)
 
-            print(f"  Uploaded: {local_filename},{attach_loc},{url}", flush=True)
         logging.debug("Upload to file server complete")
+
 
         return url, attach_loc
 

--- a/image_client.py
+++ b/image_client.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import datetime
 import logging
 import os
-from monitoring_tools import add_imagepath_to_txt
+from monitoring_tools import add_imagepath_to_html
 from string_utils import remove_non_numerics
 TIME_FORMAT = "%Y-%m-%d %H:%M:%S%z"
 
@@ -114,7 +114,7 @@ class ImageClient:
         r = requests.post(url, files=files, data=data)
         if r.status_code != 200:
             print(f"Image upload aborted: {r.status_code}:{r.text}")
-            add_imagepath_to_txt(local_filename, barcode=remove_non_numerics(os.path.basename(local_filename)),
+            add_imagepath_to_html(local_filename, barcode=remove_non_numerics(os.path.basename(local_filename)),
                                  success=False)
             raise UploadFailureException
         else:
@@ -130,7 +130,7 @@ class ImageClient:
             assert r.status_code == 200
             logging.info(f"Uploaded: {local_filename},{attach_loc},{url}")
             print("adding to image")
-            add_imagepath_to_txt(path=local_filename, barcode=remove_non_numerics(os.path.basename(local_filename)),
+            add_imagepath_to_html(path=local_filename, barcode=remove_non_numerics(os.path.basename(local_filename)),
                                  success=True)
 
         logging.debug("Upload to file server complete")

--- a/importer.py
+++ b/importer.py
@@ -17,7 +17,6 @@ from os.path import isfile, join
 import traceback
 import hashlib
 
-
 class ConvertException(Exception):
     pass
 

--- a/iz_importer.py
+++ b/iz_importer.py
@@ -11,7 +11,7 @@ import logging
 from gen_import_utils import generate_token
 # from dir_tools import DirTools
 from metadata_tools import MetadataTools
-from monitoring_tools import create_monitoring_report
+from monitoring_tools import create_monitoring_report, send_out_emails
 import traceback
 from time_utils import get_pst_time_now_string
 
@@ -55,16 +55,20 @@ class IzImporter(Importer):
         self.cur_extract_casiz = self.extract_casiz
         self.directory_tree_core = DirectoryTree(iz_importer_config.IZ_SCAN_FOLDERS)
         self.directory_tree_core.process_files(self.build_filename_map)
-        self.batch_size = 0
+        self.barcodes_processed = len(self.casiz_filepath_map.keys())
         # placeholder for filename now
         self.batch_md5 = generate_token(timestamp=get_pst_time_now_string(), filename=uuid4())
 
         print("Starting to process loaded core files...")
-        self.process_loaded_files()
 
-        create_monitoring_report(batch_size=self.batch_size, batch_md5=self.batch_md5,
+        create_monitoring_report(num_barcodes=self.barcodes_processed, batch_md5=self.batch_md5,
                                  agent=iz_importer_config.AGENT_ID,
                                  config_file=iz_importer_config)
+
+        self.process_loaded_files()
+
+        send_out_emails(subject=f"IZ_BATCH:{get_pst_time_now_string()}",
+                        config=iz_importer_config)
 
 
 

--- a/iz_importer.py
+++ b/iz_importer.py
@@ -11,7 +11,7 @@ import logging
 from gen_import_utils import generate_token
 # from dir_tools import DirTools
 from metadata_tools import MetadataTools
-from monitoring_tools import create_monitoring_report, send_out_emails
+from monitoring_tools import create_monitoring_report, send_monitoring_report
 import traceback
 from time_utils import get_pst_time_now_string
 
@@ -67,8 +67,8 @@ class IzImporter(Importer):
 
         self.process_loaded_files()
 
-        send_out_emails(subject=f"IZ_BATCH:{get_pst_time_now_string()}",
-                        config=iz_importer_config)
+        send_monitoring_report(subject=f"IZ_BATCH:{get_pst_time_now_string()}",
+                               config=iz_importer_config)
 
 
 

--- a/iz_importer_config.template.py
+++ b/iz_importer_config.template.py
@@ -9,6 +9,9 @@ PASSWORD = 'redacted'
 
 COLLECTION_NAME = 'IZ'
 
+# agent if in DB
+AGENT_ID = 123456
+
 MINIMUM_ID_DIGITS = 5
 IMAGE_SUFFIX = '[a-z\-\(\)0-9 ©_,.]*(.(jpg|jpeg|tiff|tif|png|PNG))$'
 CASIZ_NUMBER = '([0-9]{2,})'

--- a/iz_importer_config.template.py
+++ b/iz_importer_config.template.py
@@ -37,6 +37,15 @@ EXIF_DECODER_RING = {
 }
 
 
-# list of custom summary terms to add to monitoring email template
-SUMMARY_TERMS = ["term1", "term2"]
-mailing_list = ['list of email addresses']
+# config fields for monitoring emails
+SUMMARY_TERMS = ['list of summary stats to add ']
+
+SUMMARY_IMG = ['list of graph/image filepaths to add to report']
+
+mailing_list = ['list of emails to send report to']
+
+#smpt terms
+smtp_user = "your email"
+smtp_server = "smtp.gmail.com"
+smtp_port = 587
+smtp_password = "your app password"

--- a/iz_importer_config.template.py
+++ b/iz_importer_config.template.py
@@ -32,3 +32,8 @@ EXIF_DECODER_RING = {
     33432: 'Copyright',
     270: 'ImageDescription'
 }
+
+
+# list of custom summary terms to add to monitoring email template
+SUMMARY_TERMS = ["term1", "term2"]
+mailing_list = ['list of email addresses']

--- a/monitoring_tools.py
+++ b/monitoring_tools.py
@@ -1,0 +1,119 @@
+
+import time_utils
+import subprocess
+
+def send_txt_to_email(subject, recipient, file):
+    """send_txt_to_email: uses the subproccess package in order to send
+       emails from command line.
+       args:
+            subject: the subject line of the email
+            recipient: the email address of the recipient
+            file: the text file to copy to an email
+    """
+    email_command = f'cat {file} | mail -s "{subject}" {recipient}'
+    try:
+        subprocess.run(email_command, shell=True, check=True)
+        print(f"Email sent to {recipient} with subject: {subject}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error sending email: {e}")
+
+
+def clear_txt(path):
+    """clears out the all the contents of a .txt file , leaving a blank file"""
+    with open(path, 'w') as file:
+        pass
+
+def add_imagepath_to_txt(path, failure=False):
+    """add_filepath_to_monitor_txt: adds single line to end of txt file,
+        in this case with 4 spaces,
+        to keep alignment with generic template
+        args:
+            path: path to the txt file
+            failure: indicates whether image at filepath failed to upload to image server or not
+    """
+    if failure is True:
+        monitor_line = " "*4 + f"{path} -- Upload Failure"
+    else:
+        monitor_line = " "*4 + f"{path}"
+    with open("import_monitoring.txt", "a") as file:
+        file.write(f'{monitor_line}\n')
+
+def add_line_between(txt_file, line_num, string):
+    """add_line_between: used to add a string line into a txt file, between two existing lines,
+       using a line index.
+       args:
+            txt_file: path to txt file to read
+            line_num: the line number after which to insert a new line/lines of text
+            string: the actual line of text you wish to insert."""
+    with open(txt_file, "r") as file:
+        lines = file.readlines()
+
+    lines.insert(line_num, string + "\n")
+
+    with open(txt_file, "w") as file:
+        file.writelines(lines)
+
+def create_summary_term_list(value_list, config):
+    """create_summary_term_list: parses list of custom summary terms to add to template.
+        value list: the list of values to assign to each custom term, in order.
+        config: the config file from which to get the SUMMARY_TERMS list.
+    """
+    if value_list is None:
+        return None
+    else:
+        terms = ""
+        for index, term in enumerate(config.SUMMARY_TERMS):
+            terms += f"""- {term}:{value_list[index]}\n""" + " "*4
+        return terms
+
+def add_format_batch_report(num_records, uploader, md5_code, config, custom_terms):
+    """add_format_batch_report:
+        creates template of upload batch report. Takes standard summary terms and args,
+       and allows for custom terms to be added with custom_terms.
+       args:
+            num_records: the number of records uploaded to DB
+            uploader: agent id , or name of uploader.
+            md5_code: the md5 code of this current upload batch.
+            config: the config file to use.
+            custom_terms: the list of custom values to add as summary terms, myst correspond with order of
+                          SUMMARY_TERMS variable in config."""
+    if custom_terms is None:
+        custom_terms = ""
+    else:
+        pass
+
+    report = f"""Upload Batch Report:
+    -------------------
+
+    Date and Time: {time_utils.get_pst_time_now_string()}
+    Uploader: {uploader}
+    Batch md5: {md5_code}
+
+    Summary:
+    - Number of Records Added: {num_records}
+    {custom_terms}
+    
+    Images_Uploaded:
+    """
+
+    add_line_between("import_monitoring.txt", line_num=0, string=report)
+
+
+    for email in config.mailing_list:
+        send_txt_to_email(subject=f"Batch Upload:{time_utils.get_pst_time_now_string()}", recipient=email,
+                          file="import_monitoring.txt")
+
+def create_monitoring_report(batch_size, batch_md5, agent_number, config_file, value_list=None):
+    """creates customizable report template, and then sends it the form of an email
+        args:
+            value_list: the list of values to use for custom terms.
+            batch_size: the size of your upload batch.
+            batch_md5: the md5 code of your upload batch
+            agent_number: the agent id or name of person who ran the import script.
+            config_file: the config file to use
+            """
+    custom_terms = create_summary_term_list(config=config_file, value_list=value_list)
+
+    add_format_batch_report(num_records=batch_size,
+                            md5_code=batch_md5, uploader=agent_number, config=config_file,
+                            custom_terms=custom_terms)

--- a/picturae_config.template.py
+++ b/picturae_config.template.py
@@ -24,3 +24,9 @@ DATA_FOLDER = f"picturae_csv{sla}"
 CSV_SPEC = f"{sla}picturae_specimen("
 
 CSV_FOLD = f"{sla}picturae_folder("
+
+# list of custom summary terms to add to monitoring email template
+SUMMARY_TERMS = ['Number of Taxa Added', "Number of Taxa Dropped by TNRS"]
+
+# these are used for people who need batch monitoring
+mailing_list = ['list of email addresses']

--- a/picturae_config.template.py
+++ b/picturae_config.template.py
@@ -16,7 +16,8 @@ PIC_SCAN_FOLDERS = [f'PIC_{date_str}']
 PREFIX = f"web-asset-server{sla}image_client{sla}"
 
 # number for created by agent field , check your agent id on the agent table
-agent_number = 123456
+
+AGENT_ID= 123456
 
 
 DATA_FOLDER = f"picturae_csv{sla}"

--- a/picturae_csv_create.py
+++ b/picturae_csv_create.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import picturae_config
 import logging
 from taxon_parse_utils import *
-from picturae_import_utils import *
+from gen_import_utils import *
 from string_utils import *
 from importer import Importer
 from sql_csv_utils import SqlCsvTools
@@ -21,9 +21,8 @@ class CsvCreatePicturae(Importer):
     def __init__(self, date_string, logger):
         super().__init__(picturae_config, "Botany")
 
-        self.init_all_vars(date_string)
-
         self.logger = logger
+        self.init_all_vars(date_string)
 
         self.run_all()
 
@@ -470,10 +469,11 @@ class CsvCreatePicturae(Importer):
         # writing csv for inspection and upload
         self.write_upload_csv()
 
-#
+
 # def full_run():
 #     """testing function to run just the first piece o
 #           f the upload process"""
+#     # logger = logging.getLogger("full_run")
 #     CsvCreatePicturae(date_string="2023-06-28")
 #
 # full_run()

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -5,7 +5,7 @@
 import atexit
 import picturae_config
 from uuid import uuid4
-from picturae_import_utils import *
+from gen_import_utils import *
 import logging
 from string_utils import *
 from importer import Importer
@@ -44,7 +44,7 @@ class PicturaeImporter(Importer):
 
         self.batch_size = len(self.record_full)
 
-        self.batch_md5 = self.sql_csv_tools.generate_token(starting_time_stamp, self.file_path)
+        self.batch_md5 = generate_token(starting_time_stamp, self.file_path)
 
         self.run_all_methods()
 
@@ -91,7 +91,7 @@ class PicturaeImporter(Importer):
         for param in init_list:
             setattr(self, param, None)
 
-        self.created_by_agent = picturae_config.agent_number
+        self.created_by_agent = picturae_config.AGENT_ID
 
         self.paths = paths
 
@@ -955,4 +955,4 @@ class PicturaeImporter(Importer):
         value_list = [len(self.new_taxa), self.records_dropped]
 
         create_monitoring_report(value_list=value_list, batch_size=self.batch_size, batch_md5=self.batch_md5,
-                                 agent_number=picturae_config.agent_number, config_file=picturae_config)
+                                 agent=picturae_config.AGENT_ID, config_file=picturae_config)

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -17,7 +17,7 @@ from specify_db import SpecifyDb
 import picdb_config
 import time_utils
 import logging.handlers
-from monitoring_tools import create_monitoring_report, send_out_emails, insert_images_to_html
+from monitoring_tools import create_monitoring_report, send_monitoring_report
 
 class PicturaeImporter(Importer):
     """DataOnboard:
@@ -947,11 +947,7 @@ class PicturaeImporter(Importer):
 
         self.upload_attachments()
 
-
-        insert_images_to_html("tests/test_images/test_image.jpg", title='image of woodshop')
-
-
-        send_out_emails(subject=f"PIC_Batch:{time_utils.get_pst_time_now_string()}", config=picturae_config)
+        send_monitoring_report(config=picturae_config, subject=f"PIC_Batch{time_utils.get_pst_time_now_string()}")
 
         # writing time stamps to txt file
 

--- a/picturae_readme.txt
+++ b/picturae_readme.txt
@@ -60,6 +60,10 @@ file list:
                                  contains a date_str variable that can be changed in the command line (default behavior
 
 
+    monitoring_tools.py: a toolbox of function with which to parse a summary report of upload batches, and send
+                         a formatted version through email.
+
+
     specify7_ipup : used to update ip addresses in config and settings files.
     R files:
         R_TNRS: a taxonomic name resolver in the taxon_check/ folder. Further details in .readme.txt

--- a/specify_db.py
+++ b/specify_db.py
@@ -1,5 +1,4 @@
 from db_utils import DbUtils
-import logging
 class SpecifyDb(DbUtils):
     def __init__(self, db_config_class):
 

--- a/sql_csv_utils.py
+++ b/sql_csv_utils.py
@@ -1,6 +1,6 @@
 import traceback
 import pandas as pd
-from picturae_import_utils import remove_two_index
+from gen_import_utils import remove_two_index
 import time_utils
 from datetime import datetime
 from datetime import timedelta
@@ -334,19 +334,3 @@ class SqlCsvTools():
                                            val_list=val_list)
 
         return sql
-
-    def generate_token(self, timestamp, filename):
-        """Generate the auth token for the given filename and timestamp.
-        This is for comparing to the client submited token.
-        args:
-            timestamp: starting timestamp of upload batch
-            file_name: the name of the datafile that was uploaded
-        """
-        timestamp = str(timestamp)
-        if timestamp is None:
-            print(f"Missing timestamp; token generation failure.")
-        if filename is None:
-            print(f"Missing filename, token generation failure.")
-        mac = hmac.new(settings.KEY.encode(), timestamp.encode() + filename.encode(), digestmod='md5')
-        print(f"Generated new token for {filename} at {timestamp}.")
-        return ':'.join((mac.hexdigest(), timestamp))

--- a/tests/taxon_tree_dump.sh
+++ b/tests/taxon_tree_dump.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# mysqldump -u [username] -p -h [hostname] [database_name] taxon > taxon_dump.sql
+
+mysqldump -u botanist -p -h ntobiko casbotany taxon > taxon_dump.sql
+
+echo -n 'YourASCI' | xxd -ps
+
+# sed -i 's/_binary ''/1/g' taxon_dump.sql  # Replace _binary '' with 1
+# enter password
+# in taxon_dump.sql
+# delete : LOCK TABLES `taxon` WRITE;
+# delete:  ENGINE=InnoDB AUTO_INCREMENT=259815 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci
+# change:  Auto Increment to INTEGER PRIMARY KEY
+# change: int(11) to INTEGER
+# change: bit(1) to INTEGER
+sqlite3 casbotany_lite.db < taxon_dump.sql

--- a/tests/test_sql_tools.py
+++ b/tests/test_sql_tools.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 import pandas as pd
 import os
-from picturae_import_utils import remove_two_index
+from gen_import_utils import remove_two_index
 from tests.pic_importer_test_class import TestPicturaeImporter
 from tests.testing_tools import TestingTools
 from uuid import uuid4

--- a/tests/test_taxontree.py
+++ b/tests/test_taxontree.py
@@ -7,7 +7,7 @@ import pandas as pd
 from uuid import uuid4
 from tests.pic_importer_test_class_lite import TestPicturaeImporterlite
 from tests.testing_tools import TestingTools
-from picturae_import_utils import unique_ordered_list
+from gen_import_utils import unique_ordered_list
 os.chdir("./image_client")
 
 


### PR DESCRIPTION
The template, workable with multiple import processes, it is created by a function which parses it with a few core summary terms, with additional summary terms able to be added through the config file depending on need. The criterion whether an image "passes" is in the upload_to_image_server function in image_client, where a 200 code yields a positive and anything else yielding a --uploaded failed  flag on the image path.

Right now the report generation is done through a master function can be added to the end of each import script, but I only added it to the end of the picturae_importer for now pending further PR feedback.

Main Files modified include:
picturae_importer.py
client_tools.py
image_client.py
picturae_config.template
ich_config.template
iz_config.template

Files created:
monitoring_tools.py