### PR TITLE
email only sends when images processed, bug fixed with multiple recip…

### DIFF
--- a/monitoring_tools.py
+++ b/monitoring_tools.py
@@ -238,13 +238,15 @@ class MonitoringTools:
                   WHERE TimestampCreated >= '{str(time_stamp)}';"""
 
         batch_size = self.sql_csv_tools.get_record(sql=sql)
-
-        self.add_batch_size(batch_size=batch_size)
-        msg = self.attach_html_images()
-        for email in self.config.mailing_list:
+        if batch_size > 0:
+            self.add_batch_size(batch_size=batch_size)
+            msg = self.attach_html_images()
             msg['From'] = "ibss-crontab@calacademy.org"
-            msg['To'] = email
             msg['Subject'] = subject
+            recipient_list = []
+            for email in self.config.mailing_list:
+                recipient_list.append(email)
+            msg['To'] = recipient_list
             # with smtplib.SMTP(port=self.config.smtp_port, host=self.config.smtp_server) as server:
             #     server.starttls()
             #     server.login(user=self.config.smtp_user, password=self.config.smtp_password)

--- a/temp_utility_scripts/remove_incomplete_attachments.py
+++ b/temp_utility_scripts/remove_incomplete_attachments.py
@@ -1,11 +1,10 @@
 import pandas as pd
 from sql_csv_utils import SqlCsvTools
-import picturae_config
 import logging
 from importer import Importer
 from gen_import_utils import cont_prompter
-import string_utils
-
+from string_utils import remove_non_numerics
+import picturae_config
 class RemovePartialAttachments(Importer):
     def __init__(self, config):
         super().__init__(db_config_class=config, collection_name="Botany")
@@ -52,7 +51,7 @@ class RemovePartialAttachments(Importer):
             test_orig_filelist.append(origfile_list[index])
             file_path_count.append(filepath[0])
             self.logger.warning(f"removing internal file path: {filepath[0]}")
-            self.image_client.delete_from_image_server(attach_loc=filepath[0], collection=picturae_config.COLLECTION_NAME)
+            self.image_client.delete_from_image_server(attach_loc=filepath[0], collection=self.config.COLLECTION_NAME)
 
 
         sql = f'''DELETE FROM attachment WHERE AttachmentID IN ({column_list});'''
@@ -73,7 +72,7 @@ class RemovePartialAttachments(Importer):
 
         combine_tab = combine_tab[['internal_filename', 'original_filename']]
 
-        combine_tab['original_filename'] = combine_tab['original_filename'].apply(string_utils.remove_non_numerics)
+        combine_tab['original_filename'] = combine_tab['original_filename'].apply(remove_non_numerics)
 
         barcode_test_count = []
         filepath_test_count = []
@@ -93,6 +92,7 @@ class RemovePartialAttachments(Importer):
 
             self.logger.info(f"removing unattached filepath: {row['internal_filename']}")
             self.image_client.delete_from_image_server(attach_loc=internal_filename, collection='Botany')
+            filepath_test_count.append(internal_filename)
             for filepath in internal_filepaths:
                 self.logger.info(f"removing associated filepath: {filepath[0]}")
                 filepath_test_count.append(filepath[0])
@@ -115,3 +115,6 @@ class RemovePartialAttachments(Importer):
         self.logger.warning(f"Number of barcodes processed: {len(barcode_test_count)}")
         self.logger.warning(f"Number filepaths deleted from image_server: {len(filepath_test_count)}")
         self.logger.warning(f"Number of attachments/collectionobjectattachments deleted: {len(attachment_id_test_count)}")
+
+
+RemovePartialAttachments(config=picturae_config)


### PR DESCRIPTION
files changed:
monitoring_tools.py: only sends email when batch size is > 0 , uses list to send emails at once instead of with forloop.
remove_incomplete_attachments.py: just in case ever want to use this again, now  counts original path too when tallying image_paths deleted from db.