### PR TITLE
made taxon import process more robust, and other changes

### DIFF
--- a/image_client.py
+++ b/image_client.py
@@ -1,3 +1,5 @@
+import json
+
 import requests, hmac
 import time
 import sys
@@ -153,6 +155,43 @@ class ImageClient:
         }
 
         return self.decode_response(params)
+
+    def update_exif_image_data(self, exif_ring, collection, filename):
+        data = {'filename': filename,
+                'coll': collection,
+                'exif_ring': json.dumps(exif_ring),
+                'token': self.generate_token(filename)
+                }
+
+        url = self.build_url("updatemetadata")
+
+        print(url)
+
+        r = requests.post(url, data=data)
+
+        if r.status_code != 200:
+            print(f"exif update aborted: {r.status_code}:{r.text}")
+
+        logging.debug(f"modifying exif data for {filename} complete")
+
+
+    def read_exif_image_data(self, collection, filename, datatype):
+        params = {'filename': filename,
+                'coll': collection,
+                'dt': datatype,
+                'search_type': 'filename',
+                'token': self.generate_token(filename)
+        }
+        url = self.build_url("getmetadata")
+
+        response = requests.get(url=url, params=params)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return None
+
+
 
 
 

--- a/monitoring_tools.py
+++ b/monitoring_tools.py
@@ -172,13 +172,9 @@ class MonitoringTools:
         """creates customizable report template
             args:
                 value_list: the list of values to use for custom terms.
-                batch_size: the size of your upload batch.
-                batch_md5: the md5 code of your upload batch
-                agent_number: the agent id or name of person who ran the import script.
-                config_file: the config file to use
                 """
         self.clear_txt()
-        if not self.config['SUMMARY_TERMS']:
+        if self.config['SUMMARY_TERMS']:
             custom_terms = self.create_summary_term_list(value_list=value_list)
             self.add_format_batch_report(custom_terms=custom_terms)
         else:

--- a/picturae_csv_create.py
+++ b/picturae_csv_create.py
@@ -256,11 +256,14 @@ class CsvCreatePicturae(Importer):
                 if "var." in full_name or "subsp." in full_name or " f." in full_name or "subf." in full_name:
                     hybrid_base = full_name
                     full_name = " ".join(taxon_strings[:2])
-                else:
+                elif full_name != genus and full_name == gen_spec:
                     hybrid_base = full_name
                     full_name = taxon_strings[0]
-                    if full_name != genus:
-                        full_name = " ".join(taxon_strings[:2])
+                elif full_name == genus:
+                    hybrid_base = full_name
+                    full_name = full_name
+                else:
+                    self.logger.error('hybrid base not found')
 
             elif len(first_intra) != len(full_name):
                 if "var." in full_name or "subsp." in full_name or " f." in full_name or "subf." in full_name:
@@ -352,6 +355,14 @@ class CsvCreatePicturae(Importer):
 
 
     def check_taxa_against_database(self):
+        """check_taxa_against_database:
+                concatenates every taxonomic column together to get the full taxonomic name,
+                checks full taxonomic name against database and retrieves taxon_id if present
+                and `None` if absent from db. In TNRS, only taxonomic names with a `None`
+                result will be checked.
+                args:
+                    None"""
+
         col_list = ['Genus', 'Species', 'Rank 1', 'Epithet 1', 'Rank 2', 'Epithet 2']
 
         self.record_full['fulltaxon'] = ''

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -367,7 +367,11 @@ class PicturaeImporter(Importer):
         """
         self.gen_spec_id = None
         self.taxon_list = []
-        self.taxon_id = self.sql_csv_tools.taxon_get(name=self.full_name)
+        if self.is_hybrid is False:
+            self.taxon_id = self.sql_csv_tools.taxon_get(name=self.full_name)
+        else:
+            self.taxon_id = self.sql_csv_tools.taxon_get(name=self.full_name,
+                                                         taxname=self.tax_name, hybrid=True)
         # append taxon full name
         if self.taxon_id is None:
             self.taxon_list.append(self.full_name)

--- a/picturae_readme.txt
+++ b/picturae_readme.txt
@@ -35,7 +35,7 @@ file list:
 
                           taxa_unmatch : taxa which did not pass TNRS successfully
                           picturaetaxa_added: new taxa added to the database
-                          And creates and upload log:
+                          And creates and nb upload log:
                           picturae_batch: tracks each upload with timestamps and MD5 code,
                                            can be used for purging or troubleshooting.
 

--- a/test_csv_purge_sql/image_server_purge.sql
+++ b/test_csv_purge_sql/image_server_purge.sql
@@ -1,2 +1,2 @@
 # removes images from image server uploaded in last X days
-DELETE FROM images WHERE datetime > (now() - interval  1 day );
+DELETE FROM images WHERE datetime > (now() - interval  3 day );

--- a/tests/test_metadata_tools.py
+++ b/tests/test_metadata_tools.py
@@ -1,5 +1,5 @@
 import unittest
-
+from gen_import_utils import read_json_config
 import pandas as pd
 import shutil
 from metadata_tools import MetadataTools
@@ -7,7 +7,8 @@ class TestMetadataTools(unittest.TestCase):
 
     def setUp(self):
         self.path = "tests/test_images/test_image.jpg"
-        self.md = MetadataTools(self.path)
+        self.config = read_json_config(collection="Botany_PIC")
+        self.md = MetadataTools(config=self.config, path=self.path)
         shutil.copyfile("tests/test_images/test_image.jpg", "tests/test_images/image_backup.jpg")
 
     def test_is_file_larger_than(self):


### PR DESCRIPTION
-made taxon import process more robust, by allowing for species level hybirds with single names "Salix x ambigua"
or with cross names "Genus species A X Species B".  Now avoid duplicating  the taxon table database records for hybrids with different word order like , now "Genus Species A X Species B" will be recognized as the same as "Genus Species B x Species A", and 1 new taxonomic name instead of 2 will be created.

-fixed issue with custom summary terms not appearing on html report, accidental if False instead of if True , lead to a step being skipped.

-removed a inconvenience with exiftools where it would create a bunch of "filename.jpg_original" copies every time it was run. cluttering the image folders. 

-metadata now added on import , this was an uncommitted change from last week.