### PR TITLE
modified the undo batch process, to protect modifications not made by agent, added agentid to picbatch db DDL

### DIFF
--- a/PIC_dbcreate/Picturae_DDL.sql
+++ b/PIC_dbcreate/Picturae_DDL.sql
@@ -9,7 +9,9 @@ CREATE TABLE IF NOT EXISTS taxa_unmatch (matchID INTEGER PRIMARY KEY AUTO_INCREM
                                          author VARCHAR(128),
                                          name_matched VARCHAR(512),
                                          unmatched_terms VARCHAR(512),
-                                         overall_score FLOAT NOT NULL);
+                                         overall_score FLOAT NOT NULL,
+                                         CreatedByAgentID VARCHAR(128),
+                                         ModifiedByAgentID VARCHAR(128));
 
 CREATE TABLE IF NOT EXISTS picturaetaxa_added (newtaxID INTEGER PRIMARY KEY AUTO_INCREMENT,
                                                 TimestampCreated VARCHAR(128) NOT NULL ,
@@ -19,7 +21,9 @@ CREATE TABLE IF NOT EXISTS picturaetaxa_added (newtaxID INTEGER PRIMARY KEY AUTO
                                                 fullname VARCHAR(512),
                                                 name varchar(512),
                                                 family varchar(512),
-                                                hybrid BIT);
+                                                hybrid BIT,
+                                                CreatedByAgentID VARCHAR(128),
+                                                ModifiedByAgentID VARCHAR(128));
 
 
 
@@ -29,7 +33,9 @@ CREATE TABLE IF NOT EXISTS  picturae_batch (batchID INTEGER PRIMARY KEY AUTO_INC
                                              TimestampModified VARCHAR(128) NOT NULL ,
                                              StartTimeStamp TEXT NOT NULL ,
                                              EndTimeStamp TEXT NOT NULL,
-                                             batch_size INTEGER);
+                                             batch_size INTEGER,
+                                             CreatedByAgentID VARCHAR(128),
+                                             ModifiedByAgentID VARCHAR(128));
     #
 # DROP TABLE picturaetaxa_added;
 # #

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ python client_tools.py Botany import -t /images/botany/test.jpg
 
 collection/operation specific flags include:
 
-'-d' for date (yyyy-mm-dd) used for picturae import.
+'-d' for date (yyyy-mm-dd), used for picturae import batches.
 ```
 python client_tools.py -d 11-12-2023 Botany_PIC import
 ```
-'-uf' for forced update for skipping database checks in update.
+'-uf' for forced update, used for skipping database checks in update.
 ```
 python client_tools.py -uf True Botany_PIC update
 ```
@@ -51,7 +51,7 @@ python client_tools.py -uf True Botany_PIC update
 ```
 python client_tools.py -m "2c0d19fcc4a94043dfdd005f691828ba" Botany_PIC purge
 ```
-For more detail on collections import processes at the California Academy of Sciences, click [here](https://docs.google.com/document/d/1uHnZve2TuOR1bplnHgYHbpFlT8Ph6Hwvxqb3wfCO_SM/edit?usp=sharing):
+For more detail on our collections import processes at the California Academy of Sciences, click [here](https://docs.google.com/document/d/1uHnZve2TuOR1bplnHgYHbpFlT8Ph6Hwvxqb3wfCO_SM/edit?usp=sharing):
 
 
 ### Searching

--- a/botany_importer.py
+++ b/botany_importer.py
@@ -85,8 +85,8 @@ class BotanyImporter(Importer):
 
         self.import_to_imagedb_and_specify(filepath_list,
                                            collection_object_id,
-                                           95728,
-                                           force_redacted=force_redacted)
+                                           self.botany_importer_config['AGENT_ID'],
+                                           force_redacted)
 
 
 

--- a/picturae_csv_create.py
+++ b/picturae_csv_create.py
@@ -417,9 +417,6 @@ class CsvCreatePicturae(Importer):
 
         unmatched_taxa = resolved_taxon[resolved_taxon["overall_score"] < .99]
 
-        # writing unmatched taxa to db table taxa_unmatch
-        SpecifyDb(db_config_class=self.picdb_config)
-
         if len(unmatched_taxa) > 0:
             self.batch_sql_tools.taxon_unmatch_insert(unmatched_taxa=unmatched_taxa)
 

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -66,10 +66,6 @@ class PicturaeImporter(Importer):
 
         self.batch_md5 = generate_token(starting_time_stamp, self.file_path)
 
-        # setting up alternate db connection for batch database
-
-        self.batch_db_connection = SpecifyDb(db_config_class=self.picdb_config)
-
         self.monitoring_tools = MonitoringToolsDir(config=self.picturae_config,
                                                    batch_md5=self.batch_md5)
 

--- a/sql_csv_utils.py
+++ b/sql_csv_utils.py
@@ -238,14 +238,18 @@ class SqlCsvTools:
                        "TimestampModified",
                        "StartTimeStamp",
                        "EndTimeStamp",
-                       "batch_size"
+                       "batch_size",
+                       "CreatedByAgentID",
+                       "ModifiedByAgentID"
                        ]
         value_list = [f"{batch_md5}",
                       f"{time_utils.get_pst_time_now_string()}",
                       f"{time_utils.get_pst_time_now_string()}",
                       f"{time_stamp_list[0]}",
                       f"{time_stamp_list[1]}",
-                      f"{batch_size}"
+                      f"{batch_size}",
+                      f"{self.config['AGENT_ID']}",
+                      f"{self.config['AGENT_ID']}"
                       ]
 
         value_list, column_list = remove_two_index(value_list, column_list)
@@ -263,7 +267,8 @@ class SqlCsvTools:
                 val_list: list of values with which to update above list of columns(order matters)
                 condition: condition sql string used to select sub-sect of records to update.
         """
-        update_string = f''' SET TimestampModified = "{time_utils.get_pst_time_now_string()}",'''
+        update_string = f''' SET TimestampModified = "{time_utils.get_pst_time_now_string()}", 
+                            ModifiedByAgentID = "{self.config["AGENT_ID"]}",'''
         for index, column in enumerate(col_list):
             if isinstance(val_list[index], str):
                 update_string += " " + f'''{column} = "{val_list[index]}",'''
@@ -340,7 +345,9 @@ class SqlCsvTools:
                     "unmatched_terms",
                     "author",
                     "overall_score",
-                    "CatalogNumber"]
+                    "CatalogNumber",
+                    "CreatedByAgentID",
+                    "ModifiedByAgentID"]
 
         val_list = [f"{row[fullname]}",
                     f"{time_utils.get_pst_time_now_string()}",
@@ -349,7 +356,9 @@ class SqlCsvTools:
                     f"{row[unmatched_terms]}",
                     f"{row[accepted_author]}",
                     f"{row[overall_score]}",
-                    f"{row[catalog_number]}"]
+                    f"{row[catalog_number]}",
+                    f"{self.config['AGENT_ID']}",
+                    f"{self.config['AGENT_ID']}"]
 
         val_list, col_list = remove_two_index(val_list, col_list)
 
@@ -401,7 +410,9 @@ class SqlCsvTools:
                     "CatalogNumber",
                     "family",
                     "name",
-                    "Hybrid"]
+                    "Hybrid",
+                    "CreatedByAgentID",
+                    "ModifiedByAgentID"]
 
 
         val_list = [f"{row[fullname]}",
@@ -410,7 +421,11 @@ class SqlCsvTools:
                     f"{row[catalog_number]}",
                     f"{row[family]}",
                     f"{row[taxname]}",
-                       row[hybrid]]
+                       row[hybrid],
+                    f"{self.config['AGENT_ID']}",
+                    f"{self.config['AGENT_ID']}"]
+
+
 
         val_list, col_list = remove_two_index(val_list, col_list)
 


### PR DESCRIPTION
files modified:
picturae_DDL.sql: CreatedByAgentID and ModifiedByAgentID added to tables.
PIC_undo_batch: added condition to sql statements to only delete a record if created by user's agent ID, to prevent any data 
                              entered by volunteers from being accidentally erased. Added boolean to prevent picbatch record from 
                              being deleted if no table records were deleted.

sql_csv_tools: added agent id to the taxonomic tracking tables and picturae_batch tables.

picturae_import & picturae_csv_create: removed SpecifyDB init with picbatch config, as it was redundant.


