### PR TITLE
improved tnrs performance for missing taxonomic rank and added in caveat for empty locality ids.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+**api_test.py
 import_monitoring.html
 **taxon_dump.sql
 tests/test_images/test_image.jpg~

--- a/PIC_dbcreate/run_picdb.template.sh
+++ b/PIC_dbcreate/run_picdb.template.sh
@@ -1,9 +1,9 @@
 
-docker run --name picbatch-mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=picbatch -d -p 3309:3306 mysql
-docker cp PIC_dbcreate/Picturae_DDL.sql picbatch-mysql:/usr/lib/mysql
+docker run --name picbatch-mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=picbatch -d -p 3309:3306 -v $(pwd)/web-asset-importer/PIC_dbcreate:/home/ mysql:8
+#docker cp PIC_dbcreate/Picturae_DDL.sql picbatch-mysql:/usr/lib/mysql
 docker exec -it picbatch-mysql bash
 #mysql -u root -p
 #USE picbatch;
-#SOURCE /usr/lib/mysql/Picturae_DDL.sql;
+#SOURCE home/Picturae_DDL.sql;
 #exit;
 #exit

--- a/attachment_utils.py
+++ b/attachment_utils.py
@@ -64,7 +64,7 @@ class AttachmentUtils:
                                           timestampmodified, title, type, version, visibility, AttachmentImageAttributeID,
                                           CreatedByAgentID, CreatorID, ModifiedByAgentID, VisibilitySetByID)
                 VALUES ('{storename}', NULL, NULL, NULL, 
-                        '{copyright}', NULL, NULL,   '{time_utils.get_pst_date_time_from_datetime(time_utils.get_pst_time(file_created_datetime))}', '{guid}', {is_public}, NULL, 
+                        '{copyright}', NULL, NULL, '{time_utils.get_pst_date_time_from_datetime(time_utils.get_pst_time(file_created_datetime))}', '{guid}', {is_public}, NULL, 
                         NULL, NULL, '{image_type}','{original_filename}', '{url}', 4, 
                         0, NULL, NULL, 41, '{time_utils.get_pst_time_now_string()}',
                         '{time_utils.get_pst_time_now_string()}', '{".".join(basename.split(".")[:-1])}', NULL, 0, NULL, NULL, 

--- a/importer.py
+++ b/importer.py
@@ -141,6 +141,7 @@ class Importer:
                                                 agent_id=agent_id,
                                                 copyright=copyright,
                                                 is_public=is_public)
+
         attachment_id = self.attachment_utils.get_attachment_id(attachment_guid)
 
         self.connect_existing_attachment_to_collection_object_id(attachment_id, collection_object_id, agent_id)

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -859,7 +859,7 @@ class PicturaeImporter(Importer):
             if self.taxon_id is None:
                 self.create_taxon()
 
-            if self.locality_id is None:
+            if self.locality_id is None and not pd.isna(self.locality):
                 self.create_locality_record()
 
             if len(self.new_collector_list) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ toml==0.10.2
 urllib3==1.26.18
 yarg==0.1.9
 mysql-connector-python~=8.0.31
-Pillow~=10.0.1
+Pillow~=10.2.0
 anytree~=2.9.0
 colorama~=0.4.6
 pathlib~=1.0.1
@@ -37,7 +37,7 @@ cryptography~=41.0.6
 docutils~=0.18.1
 sphinx~=5.0.2
 tornado~=6.1
-jinja2~=3.1.2
+jinja2~=3.1.3
 mock~=4.0.3
 setuptools~=65.6.3
 websocket-client~=0.58.0

--- a/test_csv_purge_sql/image_server_purge.sql
+++ b/test_csv_purge_sql/image_server_purge.sql
@@ -1,2 +1,2 @@
 # removes images from image server uploaded in last X days
-DELETE FROM images WHERE datetime > (now() - interval  3 day );
+DELETE FROM images WHERE datetime > (now() - interval  15 day );

--- a/tests/test_taxon_concat_tnrs.py
+++ b/tests/test_taxon_concat_tnrs.py
@@ -3,6 +3,7 @@ import pandas as pd
 import unittest
 from tests.pic_csv_test_class import AltCsvCreatePicturae
 from tests.testing_tools import TestingTools
+from taxon_tools.BOT_TNRS import iterate_taxon_resolve
 
 class ConcatTaxonTests(unittest.TestCase, TestingTools):
     def __init__(self, *args, **kwargs):
@@ -15,15 +16,21 @@ class ConcatTaxonTests(unittest.TestCase, TestingTools):
 
         # jose Gonzalez is a real agent,
         # to make sure true matches are not added to list.
-        data = {'CatalogNumber': [12345, 12346, 12347, 12348],
-                'taxon_id': [None, None, None, None],
-                'Genus': ['x Serapicamptis', 'Castilleja', 'Rafflesia', 'Castilloja'],
-                'Species': [pd.NA, 'miniata', 'arnoldi', 'Moniata'],
-                'Rank 1': [pd.NA, 'subsp.', 'var.', pd.NA],
-                'Epithet 1': [pd.NA, 'dixonii', 'atjehensis', pd.NA],
-                'Rank 2': [pd.NA, 'var.', pd.NA, pd.NA],
-                'Epithet 2': [pd.NA, 'fake x cool', pd.NA, pd.NA],
-                'Hybrid': [True, True, False, False]
+        # abies balsamea given incorrect placeholder rank "subsp." instead of "var."
+        # to test if correct taxonomic id is filled in post-tnrs
+        data = {'CatalogNumber': [12345, 12346, 12347, 12348, 12349],
+                'fulltaxon':['x Serapicamptis', 'Castilleja miniata subsp. dixonii var. fake x fakeus',
+                             'Rafflesia arnoldi var. arjehensis', 'Castilloja Moniata',
+                             'Abies balsamea subsp. balsamea'],
+                'taxon_id': [None, None, None, None, None],
+                'Genus': ['x Serapicamptis', 'Castilleja', 'Rafflesia', 'Castilloja', 'Abies'],
+                'Species': [pd.NA, 'miniata', 'arnoldi', 'Moniata', 'balsamea'],
+                'Rank 1': [pd.NA, 'subsp.', 'var.', pd.NA, 'subsp.'],
+                'Epithet 1': [pd.NA, 'dixonii', 'atjehensis', pd.NA, 'balsamea'],
+                'Rank 2': [pd.NA, 'var.', pd.NA, pd.NA, pd.NA],
+                'Epithet 2': [pd.NA, 'fake x fakeus', pd.NA, pd.NA, pd.NA],
+                'Hybrid': [True, True, False, False, False],
+                'missing_rank': [False, False, False, False, True]
                 }
 
         self.test_csv_create_picturae.record_full = pd.DataFrame(data)
@@ -39,16 +46,16 @@ class ConcatTaxonTests(unittest.TestCase, TestingTools):
         self.assertEqual((temp_taxon_list[5]), 'Castilleja miniata')
         self.assertEqual((temp_taxon_list[6]), 'Castilleja miniata subsp. dixonii')
         self.assertEqual((temp_taxon_list[7]), 'Castilleja miniata subsp. dixonii')
-        self.assertEqual((temp_taxon_list[8]), 'fake x cool')
-        self.assertEqual((temp_taxon_list[9]), 'Castilleja miniata subsp. dixonii var. fake x cool')
+        self.assertEqual((temp_taxon_list[8]), 'fake x fakeus')
+        self.assertEqual((temp_taxon_list[9]), 'Castilleja miniata subsp. dixonii var. fake x fakeus')
         self.assertEqual((temp_taxon_list[10]), 'Rafflesia arnoldi')
         self.assertEqual((temp_taxon_list[12]), 'Rafflesia arnoldi var. atjehensis')
-        self.assertEqual(len(temp_taxon_list), 20)
+        self.assertEqual(len(temp_taxon_list), 25)
 
 
 
     def test_check_taxon_real(self):
-        """test the tnrs name resolution service in the check_taxon_real function"""
+        """tests the TNRS name resolution service in the check_taxon_real function"""
 
         self.test_csv_create_picturae.record_full[['gen_spec', 'fullname',
                                                    'first_intra',
@@ -58,15 +65,54 @@ class ConcatTaxonTests(unittest.TestCase, TestingTools):
 
         self.test_csv_create_picturae.taxon_check_tnrs()
         # assert statements
-        self.assertEqual(len(self.test_csv_create_picturae.record_full.columns), 16)
+        self.assertEqual(len(self.test_csv_create_picturae.record_full.columns), 18)
 
-        # 2 rows left as the genus level hybrid Serapicamptis and the mispelled "Castilloja" should fail
+        # 3 rows left as the genus level hybrid Serapicamptis and the mispelled "Castilloja" should fail
 
-        self.assertEqual(len(self.test_csv_create_picturae.record_full), 2)
+        self.assertEqual(len(self.test_csv_create_picturae.record_full), 3)
+
+
+
+    def test_corrected_rank_id(self):
+        """tests whether post-TNRS, that a taxonomic name with a missing or incorrect rank,
+            with update the taxon_id to that of the corrected taxonomic name."""
+
+        self.test_csv_create_picturae.record_full[['gen_spec', 'fullname',
+                                                   'first_intra',
+                                                   'taxname', 'hybrid_base']] = \
+            self.test_csv_create_picturae.record_full.apply(self.test_csv_create_picturae.taxon_concat, axis=1,
+                                                            result_type='expand')
+
+        self.test_csv_create_picturae.taxon_check_tnrs()
+
+        # assert that correct taxonomic id was filled in for Abies balsamea var. balsamea
+        self.assertEqual(self.test_csv_create_picturae.record_full.iloc[2, 2], 128210)
 
         self.assertTrue('name_matched' in self.test_csv_create_picturae.record_full.columns,
                         "does not contain name_matched")
 
+
+    def test_iterate_taxon(self):
+        """test taxonomic names with incorrect ranks"""
+
+        test_df = {'CatalogNumber': [1, 2, 3, 4],
+                   'fullname': ['Rafflesia arnoldi subsp. atjehensis', 'Bredia amoena subsp. trimera',
+                                'Sparganium eurycarpum var. coreanum', 'Aechmea fosteriana var. rupicola']
+                   }
+
+        test_df = pd.DataFrame(test_df)
+
+        resolved_taxon = iterate_taxon_resolve(test_df)
+
+        resolved_taxon = resolved_taxon[resolved_taxon['overall_score'] >= .99]
+
+        matched_list = list(resolved_taxon['name_matched'])
+
+        self.assertEqual(len(matched_list), 4)
+
+        self.assertEqual(['Rafflesia arnoldi var. atjehensis', 'Bredia amoena var. trimera',
+                          'Sparganium eurycarpum subsp. coreanum', 'Aechmea fosteriana subsp. rupicola'],
+                         matched_list)
 
 
     def tearDown(self):


### PR DESCRIPTION
files significantly changed:

picturae_csv_create.py: split off new function called cleanup_tnrs, which handles the data wrangling cleanup after running, other changes in comments ....

BOT_TNRS.py :  created new function iterate_taxon_resolve, to swap out infraspecific taxon, and rerun tnrs only on failed 
                           cases with missing infraspecific rank.

test_taxon_concat_tnrs.py: made 2 new tests, to verify TNRS's performance with missing or incorrect infraspecific 
                                                taxonomic rank

requirements.txt: updated package versions to improve security.




