### PR TITLE
updates picturae import to new image file structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+**api_test.py
 import_monitoring.html
 **taxon_dump.sql
 tests/test_images/test_image.jpg~

--- a/PIC_dbcreate/run_picdb.template.sh
+++ b/PIC_dbcreate/run_picdb.template.sh
@@ -1,9 +1,9 @@
 
-docker run --name picbatch-mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=picbatch -d -p 3309:3306 mysql
-docker cp PIC_dbcreate/Picturae_DDL.sql picbatch-mysql:/usr/lib/mysql
+docker run --name picbatch-mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=picbatch -d -p 3309:3306 -v $(pwd)/web-asset-importer/PIC_dbcreate:/home/ mysql:8
+#docker cp PIC_dbcreate/Picturae_DDL.sql picbatch-mysql:/usr/lib/mysql
 docker exec -it picbatch-mysql bash
 #mysql -u root -p
 #USE picbatch;
-#SOURCE /usr/lib/mysql/Picturae_DDL.sql;
+#SOURCE home/Picturae_DDL.sql;
 #exit;
 #exit

--- a/attachment_utils.py
+++ b/attachment_utils.py
@@ -64,7 +64,7 @@ class AttachmentUtils:
                                           timestampmodified, title, type, version, visibility, AttachmentImageAttributeID,
                                           CreatedByAgentID, CreatorID, ModifiedByAgentID, VisibilitySetByID)
                 VALUES ('{storename}', NULL, NULL, NULL, 
-                        '{copyright}', NULL, NULL,   '{time_utils.get_pst_date_time_from_datetime(time_utils.get_pst_time(file_created_datetime))}', '{guid}', {is_public}, NULL, 
+                        '{copyright}', NULL, NULL, '{time_utils.get_pst_date_time_from_datetime(time_utils.get_pst_time(file_created_datetime))}', '{guid}', {is_public}, NULL, 
                         NULL, NULL, '{image_type}','{original_filename}', '{url}', 4, 
                         0, NULL, NULL, 41, '{time_utils.get_pst_time_now_string()}',
                         '{time_utils.get_pst_time_now_string()}', '{".".join(basename.split(".")[:-1])}', NULL, 0, NULL, NULL, 

--- a/gen_import_utils.py
+++ b/gen_import_utils.py
@@ -47,6 +47,27 @@ def replace_slashes_in_dict(json):
         elif isinstance(value, dict):
             replace_slashes_in_dict(value)
 
+def extract_last_folders(path, number: int):
+    """truncates a path string to keep only the last n elements of a path"""
+    path_components = path.split('/')
+    return '/'.join(path_components[-number:])
+
+def picturae_paths_list(config, date):
+    """parses date arg into picturae image folder structure with prefixes"""
+    date_folders = f"{int(date) // 10000}{os.path.sep}" \
+                   f"{str(int(date) // 100 % 100).zfill(2)}{os.path.sep}" \
+                   f"{str(int(date) % 100).zfill(2)}{os.path.sep}"
+
+    config['PIC_SCAN_FOLDERS'] = [f"{date_folders}"]
+    config['date_str'] = date
+    paths = []
+    for cur_dir in config['PIC_SCAN_FOLDERS']:
+        full_dir = os.path.join(config['PREFIX'],
+                                config['BOTANY_PREFIX'],
+                                cur_dir)
+        paths.append(full_dir)
+        print(f"Scanning: {cur_dir}")
+    return paths
 
 def read_json_config(collection):
     """reads in json file and selects correct collection setting"""

--- a/importer.py
+++ b/importer.py
@@ -141,6 +141,7 @@ class Importer:
                                                 agent_id=agent_id,
                                                 copyright=copyright,
                                                 is_public=is_public)
+
         attachment_id = self.attachment_utils.get_attachment_id(attachment_guid)
 
         self.connect_existing_attachment_to_collection_object_id(attachment_id, collection_object_id, agent_id)

--- a/picturae_csv_create.py
+++ b/picturae_csv_create.py
@@ -6,6 +6,7 @@
 from taxon_parse_utils import *
 from gen_import_utils import *
 from string_utils import *
+from os import path
 from importer import Importer
 from sql_csv_utils import SqlCsvTools
 from specify_db import SpecifyDb
@@ -16,7 +17,8 @@ starting_time_stamp = datetime.now()
 
 
 class CsvCreatePicturae(Importer):
-    def __init__(self, date_string, config, logging_level):
+    def __init__(self, date_string, config, paths, logging_level):
+        self.paths = paths
         self.picturae_config = config
         self.picdb_config = read_json_config(collection="picbatch")
         super().__init__(db_config_class=self.picturae_config, collection_name="Botany")
@@ -30,6 +32,8 @@ class CsvCreatePicturae(Importer):
         """init_all_vars:to use for testing and decluttering init function,
                             initializes all class level variables  """
         self.date_use = date_string
+
+        self.path_prefix = self.paths[0]
 
         # setting up alternate db connection for batch database
 
@@ -96,7 +100,7 @@ class CsvCreatePicturae(Importer):
             folder_string: denotes whether specimen or folder level data with "folder" or "specimen"
         """
 
-        folder_path = 'picturae_csv/' + str(self.date_use) + '/picturae_' + str(csv_level) + '(' + \
+        folder_path = f'picturae_csv{path.sep}' + str(self.date_use) + f'{path.sep}picturae_' + str(csv_level) + '(' + \
                       str(self.date_use) + ').csv'
 
         folder_csv = pd.read_csv(folder_path)
@@ -337,16 +341,16 @@ class CsvCreatePicturae(Importer):
 
     def image_has_record(self):
         """checks if image name/barcode already in image_db"""
-        self.record_full['image_present'] = None
+        self.record_full['image_present_db'] = None
         for index, row in self.record_full.iterrows():
             file_name = os.path.basename(row['image_path'])
             file_name = file_name.lower()            # file_name = file_name.rsplit(".", 1)[0]
             imported = self.image_client.check_image_db_if_filename_imported(collection="Botany",
                                                                   filename=file_name, exact=True)
             if imported is False:
-                self.record_full.loc[index, 'image_present'] = False
+                self.record_full.loc[index, 'image_present_db'] = False
             else:
-                self.record_full.loc[index, 'image_present'] = True
+                self.record_full.loc[index, 'image_present_db'] = True
 
     def check_barcode_match(self):
         """checks if filepath barcode matches catalog number barcode
@@ -363,7 +367,12 @@ class CsvCreatePicturae(Importer):
     def check_if_images_present(self):
         """checks that each image exists, creating boolean column for later use"""
 
-        self.record_full['image_valid'] = self.record_full['image_path'].apply(lambda path: os.path.exists(path))
+        # truncating image_path column
+        self.record_full['image_path'] = self.record_full['image_path'].apply(
+                                         lambda path_img: extract_last_folders(path_img, 2))
+
+        self.record_full['image_valid'] = self.record_full['image_path'].apply(
+                                          lambda path_img: os.path.exists(f"{self.path_prefix}{path.sep}{path_img}"))
 
 
     def check_taxa_against_database(self):
@@ -498,7 +507,7 @@ class CsvCreatePicturae(Importer):
         """write_upload_csv: writes a copy of csv to PIC upload
             allows for manual review before uploading.
         """
-        file_path = f"PIC_upload/PIC_record_{self.date_use}.csv"
+        file_path = f"PIC_upload{path.sep}PIC_record_{self.date_use}.csv"
 
         self.record_full.to_csv(file_path, index=False)
 
@@ -543,7 +552,14 @@ class CsvCreatePicturae(Importer):
 #           f the upload process"""
 #     # logger = logging.getLogger("full_run")
 #     test_config = read_json_config(collection="Botany_PIC")
-#     CsvCreatePicturae(date_string="2023-06-28", logging_level='DEBUG', config=test_config)
+#
+#     date_override = "20230628"
+#
+#     from gen_import_utils import picturae_paths_list
+#
+#     paths = picturae_paths_list(config=test_config, date=date_override)
+#
+#     CsvCreatePicturae(date_string=date_override, logging_level='DEBUG', config=test_config, paths=paths)
 #
 #
 # full_run()

--- a/picturae_csv_create.py
+++ b/picturae_csv_create.py
@@ -11,7 +11,7 @@ from sql_csv_utils import SqlCsvTools
 from specify_db import SpecifyDb
 import logging
 from gen_import_utils import read_json_config
-from taxon_tools.BOT_TNRS import process_taxon_resolve
+from taxon_tools.BOT_TNRS import iterate_taxon_resolve
 starting_time_stamp = datetime.now()
 
 
@@ -287,6 +287,18 @@ class CsvCreatePicturae(Importer):
         for col_string in date_col_list:
             self.record_full[col_string] = pd.to_datetime(self.record_full[col_string],
                                                           format='%m/%d/%Y').dt.strftime('%Y-%m-%d')
+
+        # filling in missing subtaxa ranks for first infraspecific rank
+
+        self.record_full['missing_rank'] = pd.isna(self.record_full[f'Rank 1']) & pd.notna(
+                                           self.record_full[f'Epithet 1'])
+
+        self.record_full['missing_rank'] = self.record_full['missing_rank'].astype(bool)
+
+        self.record_full[f'Rank 1'] = self.record_full[f'Rank 1'].fillna(
+                                      self.record_full[f'Epithet 1'].apply(lambda x:
+                                                                           "subsp." if pd.notna(x) else ""))
+
         # parsing taxon columns
         self.record_full[['gen_spec', 'fullname',
                           'first_intra',
@@ -303,6 +315,8 @@ class CsvCreatePicturae(Importer):
         self.record_full['Hybrid'] = self.record_full['Hybrid'].apply(str_to_bool)
 
         self.record_full = self.record_full.replace(['', None, 'nan', np.nan], pd.NA)
+
+
 
     def barcode_has_record(self):
         """check if barcode / catalog number already in collectionobject table"""
@@ -326,8 +340,7 @@ class CsvCreatePicturae(Importer):
         self.record_full['image_present'] = None
         for index, row in self.record_full.iterrows():
             file_name = os.path.basename(row['image_path'])
-            file_name = file_name.lower()
-            # file_name = file_name.rsplit(".", 1)[0]
+            file_name = file_name.lower()            # file_name = file_name.rsplit(".", 1)[0]
             imported = self.image_client.check_image_db_if_filename_imported(collection="Botany",
                                                                   filename=file_name, exact=True)
             if imported is False:
@@ -393,7 +406,7 @@ class CsvCreatePicturae(Importer):
         bar_tax = bar_tax.drop(columns='taxon_id')
 
 
-        resolved_taxon = process_taxon_resolve(bar_tax)
+        resolved_taxon = iterate_taxon_resolve(bar_tax)
 
 
         resolved_taxon['overall_score'].fillna(0, inplace=True)
@@ -434,6 +447,15 @@ class CsvCreatePicturae(Importer):
         if self.records_dropped > 0:
             self.logger.info(f"{self.records_dropped} rows dropped due to taxon errors")
 
+        self.cleanup_tnrs()
+
+
+    def cleanup_tnrs(self):
+        """cleanup_tnrs: operations to re-consolidate rows with hybrids parsed for tnrs,
+            and rows with missing rank parsed for tnrs.
+            Separates qualifiers into new column as well.
+        """
+
         # re-consolidating hybrid column to fullname and removing hybrid_base column
         hybrid_mask = self.record_full['hybrid_base'].notna()
 
@@ -441,11 +463,34 @@ class CsvCreatePicturae(Importer):
 
         self.record_full = self.record_full.drop(columns=['hybrid_base'])
 
+        # consolidating taxonomy with replaced rank
+
+        self.record_full['missing_rank'] = self.record_full['missing_rank'].replace({'True': True,
+                                                                                     'False': False}).astype(bool)
+
+        rank_mask = (self.record_full['missing_rank'] == True) & \
+                    (self.record_full['fullname'] != self.record_full['name_matched']) & \
+                    (pd.notna(self.record_full['name_matched']))
+
+        self.record_full.loc[rank_mask, 'fullname'] = self.record_full.loc[rank_mask, 'name_matched']
+
+        self.record_full.loc[rank_mask, 'first_intra'] = \
+            self.record_full.loc[rank_mask, 'first_intra'].str.replace(" subsp. ", " var. ",
+                                                                       regex=False)
+
+        self.record_full.loc[rank_mask, 'fulltaxon'] = \
+            self.record_full.loc[rank_mask, 'fulltaxon'].str.replace(" subsp. ", " var. ")
+
         # executing qualifier separator function
         self.record_full = separate_qualifiers(self.record_full, tax_col='fullname')
 
-        self.record_full['gen_spec'] = self.record_full['gen_spec'].apply(remove_qualifiers)
+        # pulling new tax IDs for corrected missing ranks
 
+        self.record_full.loc[rank_mask, 'taxon_id'] = self.record_full.loc[rank_mask, 'fullname'].apply(
+            self.sql_csv_tools.taxon_get)
+
+
+        self.record_full['gen_spec'] = self.record_full['gen_spec'].apply(remove_qualifiers)
 
 
 
@@ -498,7 +543,7 @@ class CsvCreatePicturae(Importer):
 #           f the upload process"""
 #     # logger = logging.getLogger("full_run")
 #     test_config = read_json_config(collection="Botany_PIC")
-#     CsvCreatePicturae(date_string="2023-09-07", logging_level='DEBUG', config=test_config)
+#     CsvCreatePicturae(date_string="2023-06-28", logging_level='DEBUG', config=test_config)
 #
 #
 # full_run()

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -859,7 +859,7 @@ class PicturaeImporter(Importer):
             if self.taxon_id is None:
                 self.create_taxon()
 
-            if self.locality_id is None:
+            if self.locality_id is None and not pd.isna(self.locality):
                 self.create_locality_record()
 
             if len(self.new_collector_list) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ toml==0.10.2
 urllib3==1.26.18
 yarg==0.1.9
 mysql-connector-python~=8.0.31
-Pillow~=10.0.1
+Pillow~=10.2.0
 anytree~=2.9.0
 colorama~=0.4.6
 pathlib~=1.0.1
@@ -37,7 +37,7 @@ cryptography~=41.0.6
 docutils~=0.18.1
 sphinx~=5.0.2
 tornado~=6.1
-jinja2~=3.1.2
+jinja2~=3.1.3
 mock~=4.0.3
 setuptools~=65.6.3
 websocket-client~=0.58.0

--- a/test_csv_purge_sql/image_server_purge.sql
+++ b/test_csv_purge_sql/image_server_purge.sql
@@ -1,2 +1,2 @@
 # removes images from image server uploaded in last X days
-DELETE FROM images WHERE datetime > (now() - interval  3 day );
+DELETE FROM images WHERE datetime > (now() - interval  15 day );

--- a/tests/pic_csv_test_class.py
+++ b/tests/pic_csv_test_class.py
@@ -6,6 +6,7 @@ class AltCsvCreatePicturae(CsvCreatePicturae):
     def __init__(self, date_string):
         self.picturae_config = read_json_config(collection="Botany_PIC")
         Importer.__init__(self, db_config_class=self.picturae_config, collection_name="Botany")
+        self.paths = ["test/path/folder"]
         self.picdb_config = read_json_config(collection="picbatch")
         self.init_all_vars(date_string)
 

--- a/tests/test_check_record.py
+++ b/tests/test_check_record.py
@@ -19,9 +19,9 @@ class DatabaseChecks(unittest.TestCase, TestingTools):
         # the test barcode that is set to return a false is 58719322,
         # an unrealistically high barcode higher than digit limit in DB #
         data = {'CatalogNumber': ['530923', '58719322', '8708'],
-                'image_path': ['picturae_img/cas0530924.jpg',
-                               'picturae_img/cas58719322.jpg',
-                               'picturae_img/cas0008708.jpg'],
+                'image_path': ['CP1_20801212_BATCH_0001/cas0530924.jpg',
+                               'CP1_20801212_BATCH_0001/cas58719322.jpg',
+                               'CP1_20801212_BATCH_0001/cas0008708.jpg'],
                 'folder_barcode': ['2310_2', '2310_2', '2312_2']}
 
         self.test_csv_create_picturae.record_full = pd.DataFrame(data)
@@ -49,7 +49,7 @@ class DatabaseChecks(unittest.TestCase, TestingTools):
         """tests if image_has_record returns true for
            one real attachment in test df"""
         self.test_csv_create_picturae.image_has_record()
-        test_list = list(self.test_csv_create_picturae.record_full['image_present'])
+        test_list = list(self.test_csv_create_picturae.record_full['image_present_db'])
         self.assertEqual([True, False, False], test_list)
 
 

--- a/tests/test_file_hide.py
+++ b/tests/test_file_hide.py
@@ -14,20 +14,23 @@ class HideFilesTest(unittest.TestCase,TestingTools):
            images with sample barcodes"""
         # create test directories
 
-        self.create_test_images(barcode_list=[123456, 123457, 123458],
-                                date_string=self.md5_hash, color='red')
+        self.expected_folder = f"../storage_01/picturae/2080/12/12/CP1_{self.md5_hash}_BATCH_0001"
 
-        self.expected_image_path = f"picturae_img/PIC_{self.md5_hash}/CAS{123456}.JPG"
+        self.create_test_images(barcode_list=[123456, 123457, 123458],
+                                color='red', expected_dir=self.expected_folder)
+
+        self.expected_image_path = f"../storage_01/picturae/2080/12/12/CP1_{self.md5_hash}" \
+                                   f"_BATCH_0001/CAS{123456}.JPG"
 
         # initializing
         self.test_picturae_importer = AltPicturaeImporter(date_string=self.md5_hash, paths=self.md5_hash)
 
-        self.test_picturae_importer.image_list = [f"picturae_img/PIC_{self.md5_hash}/CAS123456.JPG"]
+        self.test_picturae_importer.image_list = [self.expected_image_path]
 
     def test_file_hide(self):
         """testing whether file_hide hides files not in barcode list"""
         self.test_picturae_importer.hide_unwanted_files()
-        files = os.listdir(f"picturae_img/PIC_{self.md5_hash}")
+        files = os.listdir(self.expected_folder)
         self.assertTrue('CAS123456.JPG' in files)
         self.assertTrue('.hidden_CAS123457.JPG')
 
@@ -35,7 +38,7 @@ class HideFilesTest(unittest.TestCase,TestingTools):
         """testing whether files are correctly unhidden after running hide_unwanted_files"""
         self.test_picturae_importer.hide_unwanted_files()
         self.test_picturae_importer.unhide_files()
-        files = os.listdir(f"picturae_img/PIC_{self.md5_hash}")
+        files = os.listdir(self.expected_folder)
         self.assertEqual(set(files), {'CAS123456.JPG', 'CAS123457.JPG', 'CAS123458.JPG'})
 
     def tearDown(self):

--- a/tests/test_taxon_concat_tnrs.py
+++ b/tests/test_taxon_concat_tnrs.py
@@ -3,6 +3,7 @@ import pandas as pd
 import unittest
 from tests.pic_csv_test_class import AltCsvCreatePicturae
 from tests.testing_tools import TestingTools
+from taxon_tools.BOT_TNRS import iterate_taxon_resolve
 
 class ConcatTaxonTests(unittest.TestCase, TestingTools):
     def __init__(self, *args, **kwargs):
@@ -15,15 +16,21 @@ class ConcatTaxonTests(unittest.TestCase, TestingTools):
 
         # jose Gonzalez is a real agent,
         # to make sure true matches are not added to list.
-        data = {'CatalogNumber': [12345, 12346, 12347, 12348],
-                'taxon_id': [None, None, None, None],
-                'Genus': ['x Serapicamptis', 'Castilleja', 'Rafflesia', 'Castilloja'],
-                'Species': [pd.NA, 'miniata', 'arnoldi', 'Moniata'],
-                'Rank 1': [pd.NA, 'subsp.', 'var.', pd.NA],
-                'Epithet 1': [pd.NA, 'dixonii', 'atjehensis', pd.NA],
-                'Rank 2': [pd.NA, 'var.', pd.NA, pd.NA],
-                'Epithet 2': [pd.NA, 'fake x cool', pd.NA, pd.NA],
-                'Hybrid': [True, True, False, False]
+        # abies balsamea given incorrect placeholder rank "subsp." instead of "var."
+        # to test if correct taxonomic id is filled in post-tnrs
+        data = {'CatalogNumber': [12345, 12346, 12347, 12348, 12349],
+                'fulltaxon':['x Serapicamptis', 'Castilleja miniata subsp. dixonii var. fake x fakeus',
+                             'Rafflesia arnoldi var. arjehensis', 'Castilloja Moniata',
+                             'Abies balsamea subsp. balsamea'],
+                'taxon_id': [None, None, None, None, None],
+                'Genus': ['x Serapicamptis', 'Castilleja', 'Rafflesia', 'Castilloja', 'Abies'],
+                'Species': [pd.NA, 'miniata', 'arnoldi', 'Moniata', 'balsamea'],
+                'Rank 1': [pd.NA, 'subsp.', 'var.', pd.NA, 'subsp.'],
+                'Epithet 1': [pd.NA, 'dixonii', 'atjehensis', pd.NA, 'balsamea'],
+                'Rank 2': [pd.NA, 'var.', pd.NA, pd.NA, pd.NA],
+                'Epithet 2': [pd.NA, 'fake x fakeus', pd.NA, pd.NA, pd.NA],
+                'Hybrid': [True, True, False, False, False],
+                'missing_rank': [False, False, False, False, True]
                 }
 
         self.test_csv_create_picturae.record_full = pd.DataFrame(data)
@@ -39,16 +46,16 @@ class ConcatTaxonTests(unittest.TestCase, TestingTools):
         self.assertEqual((temp_taxon_list[5]), 'Castilleja miniata')
         self.assertEqual((temp_taxon_list[6]), 'Castilleja miniata subsp. dixonii')
         self.assertEqual((temp_taxon_list[7]), 'Castilleja miniata subsp. dixonii')
-        self.assertEqual((temp_taxon_list[8]), 'fake x cool')
-        self.assertEqual((temp_taxon_list[9]), 'Castilleja miniata subsp. dixonii var. fake x cool')
+        self.assertEqual((temp_taxon_list[8]), 'fake x fakeus')
+        self.assertEqual((temp_taxon_list[9]), 'Castilleja miniata subsp. dixonii var. fake x fakeus')
         self.assertEqual((temp_taxon_list[10]), 'Rafflesia arnoldi')
         self.assertEqual((temp_taxon_list[12]), 'Rafflesia arnoldi var. atjehensis')
-        self.assertEqual(len(temp_taxon_list), 20)
+        self.assertEqual(len(temp_taxon_list), 25)
 
 
 
     def test_check_taxon_real(self):
-        """test the tnrs name resolution service in the check_taxon_real function"""
+        """tests the TNRS name resolution service in the check_taxon_real function"""
 
         self.test_csv_create_picturae.record_full[['gen_spec', 'fullname',
                                                    'first_intra',
@@ -58,15 +65,54 @@ class ConcatTaxonTests(unittest.TestCase, TestingTools):
 
         self.test_csv_create_picturae.taxon_check_tnrs()
         # assert statements
-        self.assertEqual(len(self.test_csv_create_picturae.record_full.columns), 16)
+        self.assertEqual(len(self.test_csv_create_picturae.record_full.columns), 18)
 
-        # 2 rows left as the genus level hybrid Serapicamptis and the mispelled "Castilloja" should fail
+        # 3 rows left as the genus level hybrid Serapicamptis and the mispelled "Castilloja" should fail
 
-        self.assertEqual(len(self.test_csv_create_picturae.record_full), 2)
+        self.assertEqual(len(self.test_csv_create_picturae.record_full), 3)
+
+
+
+    def test_corrected_rank_id(self):
+        """tests whether post-TNRS, that a taxonomic name with a missing or incorrect rank,
+            with update the taxon_id to that of the corrected taxonomic name."""
+
+        self.test_csv_create_picturae.record_full[['gen_spec', 'fullname',
+                                                   'first_intra',
+                                                   'taxname', 'hybrid_base']] = \
+            self.test_csv_create_picturae.record_full.apply(self.test_csv_create_picturae.taxon_concat, axis=1,
+                                                            result_type='expand')
+
+        self.test_csv_create_picturae.taxon_check_tnrs()
+
+        # assert that correct taxonomic id was filled in for Abies balsamea var. balsamea
+        self.assertEqual(self.test_csv_create_picturae.record_full.iloc[2, 2], 128210)
 
         self.assertTrue('name_matched' in self.test_csv_create_picturae.record_full.columns,
                         "does not contain name_matched")
 
+
+    def test_iterate_taxon(self):
+        """test taxonomic names with incorrect ranks"""
+
+        test_df = {'CatalogNumber': [1, 2, 3, 4],
+                   'fullname': ['Rafflesia arnoldi subsp. atjehensis', 'Bredia amoena subsp. trimera',
+                                'Sparganium eurycarpum var. coreanum', 'Aechmea fosteriana var. rupicola']
+                   }
+
+        test_df = pd.DataFrame(test_df)
+
+        resolved_taxon = iterate_taxon_resolve(test_df)
+
+        resolved_taxon = resolved_taxon[resolved_taxon['overall_score'] >= .99]
+
+        matched_list = list(resolved_taxon['name_matched'])
+
+        self.assertEqual(len(matched_list), 4)
+
+        self.assertEqual(['Rafflesia arnoldi var. atjehensis', 'Bredia amoena var. trimera',
+                          'Sparganium eurycarpum subsp. coreanum', 'Aechmea fosteriana subsp. rupicola'],
+                         matched_list)
 
 
     def tearDown(self):

--- a/tests/testing_tools.py
+++ b/tests/testing_tools.py
@@ -31,7 +31,7 @@ class TestingTools:
                     writer.writerow([specimen_bar, folder_barcode, jpg_path])
             print(f"Fake dataset {path} with {num_records} records created successfully")
 
-    def create_test_images(self, barcode_list: list, date_string: str, color: str):
+    def create_test_images(self, barcode_list: list, color: str, expected_dir: str):
         """create_test_images:
                 creates a number of standard test images in a range of barcodes,
                 and with a specific date string
@@ -45,7 +45,7 @@ class TestingTools:
 
         barcode_list = barcode_list
         for barcode in barcode_list:
-            expected_image_path = f"picturae_img/PIC_{date_string}/CAS{barcode}.JPG"
+            expected_image_path = expected_dir + f"/CAS{barcode}.JPG"
             os.makedirs(os.path.dirname(expected_image_path), exist_ok=True)
             print(f"Created directory: {os.path.dirname(expected_image_path)}")
             image.save(expected_image_path)


### PR DESCRIPTION
files changed:
picturae_csv_create: changed logic for the function check if images present, for new file structure
picturae_importer: changed parsing for create_file_list, hide_unwanted_files, and unhide_files functions.
client_tools: added new parsing for the paths variable for picturae_import, added in arg to only import images of existing picturae barcodes.
gen_import_utils: added new function to parse paths variable for picturae client_tools, added new function to truncate paths up to n levels. 
botany_importer: added optional arg to skip creating skeleton for existing barcodes and skip creating new attachment records for non-existing barcodes.