### PR TITLE
Picturae import

### DIFF
--- a/PIC_dbcreate/picbatch_backup.template.sh
+++ b/PIC_dbcreate/picbatch_backup.template.sh
@@ -8,7 +8,7 @@ DB_PORT="3309"
 BACKUP_DIR="/path/to/picbatch_backups"  # Replace with your actual backup directory
 LOG_FILE="/path/to/log.txt"  # output log file
 
-# create backup dir if not already exists
+# make backup directory if not already existing
 mkdir -p $BACKUP_DIR
 
 # Get the current date
@@ -18,7 +18,7 @@ CURRENT_DATE=$(date +"%Y-%m-%d")
 BACKUP_FILE="$BACKUP_DIR/${DB_NAME}_backup_$CURRENT_DATE.sql"
 
 # Perform the mysqldump
-mysqldump -u$DB_USER -p$DB_PASSWORD -P$DB_PORT $DB_NAME > $BACKUP_FILE
+mysqldump -h 127.0.0.1 -u$DB_USER -p$DB_PASSWORD -P$DB_PORT $DB_NAME > $BACKUP_FILE
 
 # Check if mysqldump was successful
 if [ $? -eq 0 ]; then

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -330,10 +330,12 @@ class PicturaeImporter(Importer):
                 last_index = column_names.index(f'collector_last_name{i}')
                 id_index = column_names.index(f'agent_id{i}')
 
-                first = row[first_index]
-                middle = row[middle_index]
-                last = row[last_index]
-                agent_id = row[id_index]
+                first = replace_apostrophes(row[first_index])
+                middle = replace_apostrophes(row[middle_index])
+                last = replace_apostrophes(row[last_index])
+                agent_id = replace_apostrophes(row[id_index])
+
+
 
 
             except ValueError:
@@ -364,7 +366,7 @@ class PicturaeImporter(Importer):
                     title = title_last
 
                 middle = middle
-                elements = [first_name, last_name, title, middle]
+                elements = [str(first_name).strip(), str(last_name).strip(), str(title).strip(), str(middle).strip()]
 
                 for index in range(len(elements)):
                     if pd.isna(elements[index]) or elements[index] == '':

--- a/sql_csv_utils.py
+++ b/sql_csv_utils.py
@@ -9,6 +9,7 @@ import sys
 from specify_db import SpecifyDb
 import logging
 from typing import Union
+import re
 import numpy as np
 
 class DatabaseConnectionError(Exception):
@@ -223,7 +224,8 @@ class SqlCsvTools:
         """
         # removing brackets, making sure comma is not inside of quotations
         column_list = ', '.join(col_list)
-        value_list = ', '.join(f"'{value}'" if isinstance(value, str) else repr(value) for value in val_list)
+        value_list = ', '.join(f"'{value}'" if isinstance(value, str) else
+                               repr(value) for value in val_list)
 
         sql = f'''INSERT INTO {tab_name} ({column_list}) VALUES({value_list});'''
 

--- a/string_utils.py
+++ b/string_utils.py
@@ -33,18 +33,21 @@ def remove_non_numerics(string: str):
 
 
 def replace_apostrophes(string: str):
-    """replaces apostrophes in possessive adjectives with double quotes to be readable by mysql
-    args:
-        string: a string containing an apostrophe
-    returns:
-        re.sub: a string with all apostrophes replaces by double quotes
     """
-    # using double quotes on one and single on the other is actually important this time
+    Replaces single apostrophes with double apostrophes for MySQL compatibility,
+    but skips already escaped double apostrophes.
+
+    Args:
+        string: A string that may contain apostrophes.
+
+    Returns:
+        str: A string with unescaped apostrophes replaced by double apostrophes.
+    """
     if isinstance(string, str):
-        return re.sub("'", "''", string)
+        # Replace single apostrophes not preceded by another apostrophe
+        return re.sub(r"(?<!')'", "''", string)
     else:
         return string
-
 
 def move_first_substring(string: str, n_char: int):
     """move_first_substring: will move first n letters from beginning to end of string

--- a/tests/test_agent_list.py
+++ b/tests/test_agent_list.py
@@ -31,7 +31,7 @@ class TestAgentList(unittest.TestCase, TestingTools):
                 'agent_id3': ['', ''],
                 'collector_first_name3': ['Jose', pd.NA],
                 'collector_last_name3': ['Gonzalez', pd.NA],
-                'collector_middle_name3': [pd.NA, pd.NA],
+                'collector_middle_name3': ['Isabel', pd.NA],
                 'sheet_notes': 'notes'
                 }
 


### PR DESCRIPTION
changes:
picturaa_importer: strip, and escpape apostrophes before inserting and querying name dictionary in importer.
string_utils: replace_apostrophes now only replaces single apostrophes and ignores pre-escaped apostrophes that are already doubles.
picbatch_backup: now fixed to work properly by referencing current host, when backup up the database.