### PR TITLE
Retry for db_utils and image_client

### DIFF
--- a/botany_importer.py
+++ b/botany_importer.py
@@ -8,9 +8,6 @@ import logging
 from dir_tools import DirTools
 from uuid import uuid4
 from time_utils import get_pst_time_now_string
-from monitoring_tools import MonitoringTools
-from attachment_utils import DatabaseInconsistentError
-from db_utils import DbUtils
 # I:\botany\PLANT FAMILIES
 #
 # I:\botany\TYPE IMAGES
@@ -40,7 +37,6 @@ class BotanyImporter(Importer):
         self.barcode_map = {}
         self.logger.debug("Botany import mode")
         self.monitoring_tools = None
-
 
         for cur_dir in self.paths:
             self.dir_tools.process_files_or_directories_recursive(cur_dir)

--- a/db_utils.py
+++ b/db_utils.py
@@ -17,6 +17,35 @@ class DataInvariantException(Exception):
     pass
 
 
+def retry_with_backoff(max_duration=10800, initial_delay=0):
+    """Decorator to retry a function with exponential backoff."""
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            start_time = time.time()
+            delay = initial_delay
+            last_error = None
+
+            while time.time() - start_time < max_duration:
+                try:
+                    return func(*args, **kwargs)  # Attempt to execute the function
+                except Exception as ex:
+                    last_error = ex
+                    args[0].logger.error(f"Error in {func.__name__}: {ex}")
+
+                args[0].logger.debug(f"Retrying {func.__name__} in {delay} seconds...")
+                time.sleep(delay)
+                delay += delay + 30  # increasing backoff
+
+            args[0].logger.error(
+                f"Failed to execute {func.__name__} within {max_duration} seconds. Last error: {last_error}")
+            return None  # Return None if all retries fail
+
+        return wrapper
+
+    return decorator
+
+
 class DbUtils:
     def __init__(self, database_user, database_password, database_port, database_host, database_name):
         self.logger = logging.getLogger(f'Client.DbUtils') # must hardcode to see base class name
@@ -26,6 +55,7 @@ class DbUtils:
         self.database_host = database_host
         self.database_name = database_name
         self.cnx = None
+
 
     def reset_connection(self):
 
@@ -38,68 +68,43 @@ class DbUtils:
         self.cnx = None
         self.connect()
 
+
+    @retry_with_backoff()
     def connect(self):
-        if self.cnx is None:
-            self.logger.debug(f"Connecting to db {self.database_host}...")
+        """Attempts to establish a database connection with logging but without redundant retry logic."""
 
-            max_duration = 10800  # 3 hours in seconds
-            start_time = time.time()
-            delay = 0  # Initial delay
-            last_error = None  # Store last encountered error
+        if self.cnx and self.cnx.is_connected():
+            return True  # Connection is already established
 
-            while time.time() - start_time < max_duration:
-                try:
-                    self.cnx = mysql.connector.connect(
-                        user=self.database_user,
-                        password=self.database_password,
-                        host=self.database_host,
-                        port=self.database_port,
-                        database=self.database_name
-                    )
-                    self.logger.info("Db connected")
-                    return  # Exit function on success
+        self.logger.debug(f"Connecting to db {self.database_host}...")
 
-                except mysql.connector.Error as err:
-                    last_error = err  # Store the last MySQL error
+        try:
+            self.cnx = mysql.connector.connect(
+                user=self.database_user,
+                password=self.database_password,
+                host=self.database_host,
+                port=self.database_port,
+                database=self.database_name
+            )
+            self.logger.info("Db connected")
+            return True  # Successfully connected
 
-                    if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
-                        self.logger.error("SQL: Access denied")
-                        sys.exit(1)  # No need to retry incorrect credentials
+        except mysql.connector.Error as err:
+            self.logger.error(f"Database connection failed: {err}")
 
-                    elif err.errno == errorcode.ER_BAD_DB_ERROR:
-                        self.logger.error("Database does not exist")
-                        sys.exit(1)  # No need to retry if database does not exist
+        except Exception as err:
+            self.logger.error(f"Unknown exception during connection: {err}")
 
-                    else:
-                        self.logger.error(f"Database connection failed: {err}")
+        return False  # Return False if connection failed
 
-                except Exception as err:
-                    last_error = err  # Store the last unknown error
-                    self.logger.error(f"Unknown exception: {err}")
 
-                self.logger.debug(f"Retrying in {delay} seconds...")
-                time.sleep(delay)
-
-                # Increase the delay by 30 seconds for the next attempt
-                delay += 30
-
-            # If we exit the loop, all attempts have failed within 3 hours
-            raise RuntimeError(f"Failed to connect to database within 3 hours. Last error: {last_error}")
-
-        else:
-            try:
-                self.cnx.ping(reconnect=True)
-            except Exception as e:
-                self.logger.warning(f"Connection not responsive: {e}. Attempting to reset connection.")
-                self.reset_connection()
-
+    @retry_with_backoff()
     def get_one_record(self, sql):
         # added buffered = true so will work properly with forloops
         cursor = self.get_cursor(buffered=True)
         try:
             cursor.execute(sql)
             retval = cursor.fetchone()
-
         except Exception as e:
             print(f"Exception thrown while processing sql: {sql}\n{e}\n", file=sys.stderr, flush=True)
             self.logger.error(traceback.format_exc())
@@ -113,6 +118,7 @@ class DbUtils:
         cursor.close()
         return retval
 
+    @retry_with_backoff()
     def get_records(self, query):
         cursor = self.get_cursor()
         cursor.execute(query)
@@ -121,17 +127,40 @@ class DbUtils:
         cursor.close()
         return record_list
 
+    @retry_with_backoff()
     def get_cursor(self, buffered=False):
         self.connect()
         cursor = self.cnx.cursor(buffered=buffered)
         return cursor
 
+
+    @retry_with_backoff()
     def execute(self, sql):
-        cursor = self.get_cursor()
+        """Executes a SQL statement with logging and connection management."""
+
         self.logger.debug(f"SQL: {sql}")
-        cursor.execute(sql)
-        self.cnx.commit()
-        cursor.close()
+
+        try:
+            if self.cnx is None or not self.cnx.is_connected():
+                self.connect()
+
+            cursor = self.cnx.cursor(buffered=True)  # Use buffered cursor
+            cursor.execute(sql)
+            self.cnx.commit()
+            cursor.close()
+            return True  # Execution successful
+
+        except mysql.connector.Error as err:
+            self.logger.error(f"SQL execution failed: {err}")
+            if err.errno in {errorcode.CR_SERVER_GONE_ERROR, errorcode.CR_SERVER_LOST}:
+                self.reset_connection()  # Reset on connection loss
+
+        except Exception as ex:
+            self.logger.error(f"Unknown error during SQL execution: {ex}")
+            self.reset_connection()  # Reset and try again
+
+        return False  # Return False on failure
+
 
     def commit(self):
         self.cnx.commit()

--- a/image_db.py
+++ b/image_db.py
@@ -1,117 +1,27 @@
 import mysql.connector
 from mysql.connector import errorcode
-from retrying import retry
-
 import settings
 from datetime import datetime
 import logging
-import traceback
 import time
-import sys
+from db_utils import DbUtils
 TIME_FORMAT_NO_OFFSET = "%Y-%m-%d %H:%M:%S"
 TIME_FORMAT = TIME_FORMAT_NO_OFFSET + "%z"
 
-
-def retry_with_backoff(max_duration=10800, initial_delay=0):
-    """Decorator to retry a function with exponential backoff."""
-
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            start_time = time.time()
-            delay = initial_delay
-            last_error = None
-
-            while time.time() - start_time < max_duration:
-                try:
-                    return func(*args, **kwargs)  # Attempt to execute the function
-                except Exception as ex:
-                    last_error = ex
-                    args[0].logger.error(f"Error in {func.__name__}: {ex}")
-
-                args[0].logger.debug(f"Retrying {func.__name__} in {delay} seconds...")
-                time.sleep(delay)
-                delay += delay + 30  # increasing backoff
-
-            args[0].logger.error(
-                f"Failed to execute {func.__name__} within {max_duration} seconds. Last error: {last_error}")
-            return None  # Return None if all retries fail
-
-        return wrapper
-
-    return decorator
-
-
-class ImageDb():
+class ImageDb(DbUtils):
     def __init__(self):
-        self.cnx = None
+        self.logger = logging.getLogger(f'Client.{self.__class__.__name__}')
+        self.image_db_connection = super().__init__(
+            settings.SQL_USER,
+            settings.SQL_PASSWORD,
+            settings.SQL_PORT,
+            settings.SQL_HOST,
+            settings.SQL_DATABASE)
 
-    def log(self, msg):
-        if settings.DEBUG_APP:
-            print(msg)
-
-    def retry_if_operational_error(exception):
-        pass
-
-
-    # @retry_with_backoff()
-    def get_cursor(self):
-        try:
-            if self.cnx is None:
-                self.connect()
-            return self.cnx.cursor(buffered=True)
-        except mysql.connector.OperationalError as e:
-            logging.warning("Failed to connect, resetting DB connection and sleeping")
-            self.reset_connection()
-            raise e
-
-    # @retry_with_backoff()
-    def reset_connection(self):
-        self.log(f"Resetting connection to {settings.SQL_HOST}")
-
-        if self.cnx:
-            try:
-                self.cnx.close()
-            except Exception:
-                pass
-        self.connect()
-
-    @retry_with_backoff()
-    def connect(self):
-        """Attempt to establish a database connection with retry logic."""
-        if self.cnx is not None:
-            try:
-                self.cnx.ping(reconnect=True)
-                return
-            except Exception as e:
-                self.log(f"Connection not responsive: {e}. Attempting to reset connection.")
-                self.reset_connection()
-                return
-
-        self.log(f"Connecting to db {settings.SQL_HOST}...")
-
-        try:
-            self.cnx = mysql.connector.connect(
-                user=settings.SQL_USER,
-                password=settings.SQL_PASSWORD,
-                host=settings.SQL_HOST,
-                port=settings.SQL_PORT,
-                database=settings.SQL_DATABASE
-            )
-            self.log("Db connected")
-        except mysql.connector.Error as err:
-            if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
-                self.log(f"SQL: Access denied. Host: {settings.SQL_HOST}, User: {settings.SQL_USER}")
-                return False
-            elif err.errno == errorcode.ER_BAD_DB_ERROR:
-                self.log("Database does not exist")
-                return False
-            else:
-                self.log(f"Database connection failed: {err}")
-                raise
-        except Exception as ex:
-            self.log(f"Unknown error: {ex}")
-            raise
-
+    @staticmethod
+    def retry_with_backoff(max_duration=10800, initial_delay=0):
+        """Custom backoff logic with a shorter retry window."""
+        return DbUtils.retry_with_backoff(max_duration, initial_delay)
 
     def create_tables(self):
         TABLES = {}
@@ -130,24 +40,24 @@ class ImageDb():
             "  `collection` varchar(50)"
             ") ENGINE=InnoDB")
 
-        cursor = self.get_cursor()
+        cursor = self.image_db_connection.get_cursor()
 
         for table_name in TABLES:
             table_description = TABLES[table_name]
             try:
-                self.log(f"Creating table {table_name}...")
-                self.log(f"Sql: {TABLES[table_name]}")
+                self.logger.info(f"Creating table {table_name}...")
+                self.logger.info(f"Sql: {TABLES[table_name]}")
                 cursor.execute(table_description)
             except mysql.connector.Error as err:
                 if err.errno == errorcode.ER_TABLE_EXISTS_ERROR:
-                    self.log("already exists.")
+                    self.logger.error("already exists.")
                 else:
-                    self.log(err.msg)
+                    self.logger.error(err.msg)
             else:
-                self.log("OK")
+                self.logger.info("OK")
 
         cursor.close()
-        cursor = self.get_cursor()
+        cursor = self.image_db_connection.get_cursor()
 
         cursor.execute(
             "SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'images' AND column_name = 'orig_md5'")
@@ -189,8 +99,8 @@ class ImageDb():
                         "{int(redacted)}", 
                         "{datetime_record.strftime(TIME_FORMAT_NO_OFFSET)}",
                         "{original_image_md5}")""")
-        self.execute(add_image)
-        self.log(f"Inserting imageInserting image record. SQL: {add_image}")
+        self.image_db_connection.execute(add_image)
+        self.logger.info(f"Inserting imageInserting image record. SQL: {add_image}")
 
     # is this necessary when we have self.execute or is this just debugging?
     @retry_with_backoff()
@@ -200,13 +110,13 @@ class ImageDb():
         """
 
         logging.debug(f"updating stop 0: {sql}")
-        cursor = self.get_cursor()
+        cursor = self.image_db_connection.get_cursor()
         logging.debug(f"updating stop 1")
 
         cursor.execute(sql)
         logging.debug(f"updating stop 2")
 
-        self.cnx.commit()
+        self.image_db_connection.cnx.commit()
         logging.debug(f"updating stop 3")
 
         cursor.close()
@@ -214,7 +124,7 @@ class ImageDb():
     @retry_with_backoff()
     def get_record(self, where_clause):
 
-        cursor = self.get_cursor()
+        cursor = self.image_db_connection.get_cursor()
 
         query = f"""SELECT id, original_filename, url, universal_url, internal_filename, collection,original_path, notes, redacted, datetime, orig_md5
            FROM images 
@@ -242,7 +152,7 @@ class ImageDb():
 
     @retry_with_backoff()
     def get_image_record_by_internal_filename(self, internal_filename):
-        cursor = self.get_cursor()
+        cursor = self.image_db_connection.get_cursor()
 
         query = f"""SELECT id, original_filename, url, universal_url, internal_filename, collection,original_path, notes, redacted, datetime, orig_md5
            FROM images 
@@ -278,7 +188,7 @@ class ImageDb():
 
     @retry_with_backoff()
     def get_image_record_by_pattern(self, pattern, column, exact, collection):
-        cursor = self.get_cursor()
+        cursor = self.image_db_connection.get_cursor()
         if exact:
             query = f"""SELECT id, original_filename, url, universal_url, internal_filename, collection,original_path, notes, redacted, datetime, orig_md5
             FROM images 
@@ -291,7 +201,7 @@ class ImageDb():
         if collection is not None:
             query += f""" AND collection = '{collection}'"""
 
-        self.log(f"Query get_image_record_by_{column}: {query}")
+        self.logger.info(f"Query get_image_record_by_{column}: {query}")
 
 
         cursor.execute(query)
@@ -301,9 +211,9 @@ class ImageDb():
         if rows:
             pass
         else:
-            self.log("No rows were returned.")
+            self.logger.warning("No rows were returned.")
 
-        self.log(f"Fetched rows: {rows}")
+        self.logger.info(f"Fetched rows: {rows}")
 
         record_list = []
 
@@ -322,7 +232,7 @@ class ImageDb():
                                 'datetime': datetime_record,
                                 'orig_md5': orig_md5
                                 })
-            self.log(f"Found at least one record: {record_list[-1]}")
+            self.logger.info(f"Found at least one record: {record_list[-1]}")
 
         cursor.close()
         return record_list
@@ -339,26 +249,20 @@ class ImageDb():
         record_list = self.get_image_record_by_pattern(md5, 'orig_md5', True, collection)
         return record_list
 
+    @retry_with_backoff()
     def delete_image_record(self, internal_filename):
-        cursor = self.get_cursor()
+        cursor = self.image_db_connection.get_cursor()
 
         delete_image = (f"""delete from images where internal_filename='{internal_filename}' ;""")
 
-        self.log(f"deleting image record. SQL: {delete_image}")
+        self.logger.info(f"deleting image record. SQL: {delete_image}")
         cursor.execute(delete_image)
-        self.cnx.commit()
+        self.image_db_connection.cnx.commit()
         cursor.close()
 
     @retry_with_backoff()
-    def execute(self, sql):
-        cursor = self.get_cursor()
-        logging.debug(f"SQL: {sql}")
-        cursor.execute(sql)
-        self.cnx.commit()
-        cursor.close()
-
     def get_collection_list(self):
-        cursor = self.get_cursor()
+        cursor = self.image_db_connection.get_cursor()
 
         query = f"""select collection from collection"""
 

--- a/importer.py
+++ b/importer.py
@@ -99,7 +99,7 @@ class Importer:
 
         jpg_dest = os.path.join(self.TMP_JPG, file_name_no_extention + ".jpg")
 
-        proc = subprocess.Popen(['magick', '-quality', '99', image_filepath, jpg_dest],
+        proc = subprocess.Popen(['convert', '-quality', '99', image_filepath, jpg_dest],
                                 stdout=subprocess.PIPE)
 
         output = proc.communicate(timeout=60)[0]

--- a/sql_csv_utils.py
+++ b/sql_csv_utils.py
@@ -118,7 +118,7 @@ class SqlCsvTools:
                             set to true to avoid re-adding unspecified as an agent id
         """
 
-        sql = "SELECT agent_id FROM agent WHERE LastName = 'unspecified';"
+        sql = "SELECT AgentID FROM agent WHERE LastName = 'unspecified';"
 
         agent_id = self.specify_db_connection.get_one_record(sql=sql)
 


### PR DESCRIPTION
Files changed:
botany_importer.py: removed junk package imports that are no longer used
db_utils.py: added retry_with_backoff decorator for functions with sql requests. 
                    - modified try except logic for get_one_record and connect and execute.
                  
image_db.py: now inherits db_utils.py class and uses the retry and base connect, execute, get_cursor functions

image_client.py:  instead of base request, now uses request_with_retries function, and cleanup_failed_fileupload for fileupload/ methods.

importer.py: removed use of image_db in remove_incomplete_attachments and replaced with image_client function.

Read more Detailed comments in files --->