### PR TITLE
removed forced sys exit after sql insert failure

### DIFF
--- a/sql_csv_utils.py
+++ b/sql_csv_utils.py
@@ -228,7 +228,6 @@ class SqlCsvTools:
             self.commit()
         except Exception as e:
             self.logger.error(traceback.format_exc())
-            sys.exit("terminating script")
         cursor.close()
 
     def create_batch_record(self, start_time: datetime, end_time: datetime,
@@ -333,7 +332,7 @@ class SqlCsvTools:
         """
         taxa_frame = df[df['fullname'].isin(taxon_list)].drop_duplicates(subset=['fullname'])
         for _, row in taxa_frame.iterrows():
-            tax_id = self.get_one_match('picturaetaxa_added', 'newtaxID', 'fullname', row['fullname'], str)
+            tax_id = self.get_one_match('picturaetaxa_added', 'newtaxID', 'fullname', row['fullname'])
             if tax_id is None:
                 sql_statement = self.create_new_tax_tab(row, 'picturaetaxa_added', agent_id)
                 self.insert_table_record(sql_statement.sql, sql_statement.params)


### PR DESCRIPTION
Removed forced sys exist after sql exception allows import to continue past syntax or unicode error. These kinds of errors are relatively easy to fix if sporadic so it is better if an import finishes fully.