### PR TITLE
fix iz ID parsing

### DIFF
--- a/config_files/iz_config.template.py
+++ b/config_files/iz_config.template.py
@@ -9,26 +9,12 @@ PASSWORD = '123pass'
 
 REPORT_PATH = f"html_reports{sla}iz_import_monitoring.html"
 COLLECTION_NAME = "IZ"
-MINIMUM_ID_DIGITS = 5
-MAXIMUM_ID_DIGITS = 12
 
 AGENT_ID = 123456
 
 # path variables
-MINIMUM_ID_DIGITS = 5
-MAXIMUM_ID_DIGITS = 10
-SHORT_MINIMUM_ID_DIGITS = 3
 IMAGE_EXTENSION = r'(\.(jpg|jpeg|tiff|tif|png|dng))$'
 IMAGE_SUFFIX = rf'[a-z\-\(\)0-9 ©_,.]*{IMAGE_EXTENSION}'
-CASIZ_NUMBER = '([0-9]{' + str(MINIMUM_ID_DIGITS) + ','+ str(MAXIMUM_ID_DIGITS)+'})'
-CASIZ_NUMBER_SHORT = '([0-9]{' + str(SHORT_MINIMUM_ID_DIGITS) + ','+ str(MAXIMUM_ID_DIGITS)+'})'
-CASIZ_PREFIX = r'cas(iz)?[#a-z _]*[_ \-]?'
-CASIZ_MATCH = rf'({CASIZ_PREFIX}{CASIZ_NUMBER_SHORT})|({CASIZ_NUMBER})'
-CASIZ_NUMBER_EXACT = rf'{CASIZ_PREFIX}([0-9]+)'
-FILENAME_MATCH = rf'{CASIZ_MATCH}{IMAGE_SUFFIX}'
-FILENAME_CONJUNCTION_MATCH = rf'(({CASIZ_MATCH})|([ ]*(and|or)[ ]*({CASIZ_MATCH})))+'
-DIRECTORY_CONJUNCTION_MATCH = FILENAME_CONJUNCTION_MATCH
-DIRECTORY_MATCH = rf'{CASIZ_MATCH}'
 
 
 IZ_SCAN_FOLDERS = [
@@ -49,3 +35,33 @@ MAILING_LIST = []
 SUMMARY_TERMS = []
 SUMMARY_IMG = []
 
+CASIZ_NUMBER_REGEX = regex.compile(
+    r'''
+    (?ix)                           # Ignore case, allow comments
+    (?<!\w)                         # No word character before
+    (                               
+      (?:
+        (?!IZACC[\s_#-]?)             # Not IZACC prefix (negative lookahead)
+        (?P<prefix>CASIZ|CAS)        # CASIZ or CAS (named group 'prefix')
+        (?:[\s_#-]*)                  # Spaces, underscores, dashes (zero or more)
+      )?
+      (?P<number>                    # --- Capture only the number ---
+        (?!
+          (?:DSC|P)\d{3,}            # Not digital camera serials
+        )
+        (?!
+          (?<!CASIZ[\s_#-]*|CAS[\s_#-]*) # unless CASIZ/CAS prefix
+          (?:(1[6-9]\d{2}|20\d{2})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))             # Dates like 20230412
+        )
+        \d{3,12}                     # 3-12 digits
+      )
+    )
+    (?(prefix)                       # If prefix matched:
+        (?=\D|$)                     # allow anything non-digit or end
+    |
+        (?=\b|[_\s#-]|$)              # else must have boundary
+    )
+    ''', regex.VERBOSE
+)
+
+CASIZ_FALLBACK_REGEX = regex.compile(r'(?i)(?:CASIZ|CAS)[\s_#-]*(\d{3,12})(?!\d)')

--- a/config_files/iz_config.template.py
+++ b/config_files/iz_config.template.py
@@ -1,4 +1,5 @@
 from os import path
+import regex
 sla = path.sep
 # database credentials
 SPECIFY_DATABASE_HOST = '127.0.0.1'

--- a/config_files/iz_config.template.py
+++ b/config_files/iz_config.template.py
@@ -36,6 +36,10 @@ MAILING_LIST = []
 SUMMARY_TERMS = []
 SUMMARY_IMG = []
 
+MINIMUM_ID_DIGITS_WITH_PREFIX = 3
+MAXIMUM_ID_DIGITS = 12
+MINIMUM_ID_DIGITS = 5
+
 CASIZ_NUMBER_REGEX = regex.compile(
     r'''
     (?ix)                           # Ignore case, allow comments
@@ -48,21 +52,31 @@ CASIZ_NUMBER_REGEX = regex.compile(
       )?
       (?P<number>                    # --- Capture only the number ---
         (?!
-          (?:DSC|P)\d{3,}            # Not digital camera serials
+          (?:DSC|P)\d{{{min_digits_with_prefix},}}     # Not camera serials
         )
         (?!
-          (?<!CASIZ[\s_#-]*|CAS[\s_#-]*) # unless CASIZ/CAS prefix
-          (?:(1[6-9]\d{2}|20\d{2})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))             # Dates like 20230412
+          (?<!CASIZ[\s_#-]*|CAS[\s_#-]*)
+          (?:(?:19|20)\d{{2}}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01]))
         )
-        \d{3,12}                     # 3-12 digits
+        \d{{{min_digits_with_prefix},{max_digits}}}
       )
     )
-    (?(prefix)                       # If prefix matched:
-        (?=\D|$)                     # allow anything non-digit or end
+    (?(prefix)
+        (?=\D|$)
     |
-        (?=\b|[_\s#-]|$)              # else must have boundary
+        (?=\b|[_\s#-]|$)
     )
-    ''', regex.VERBOSE
+    '''.format(
+        min_digits_with_prefix=MINIMUM_ID_DIGITS_WITH_PREFIX,
+        max_digits=MAXIMUM_ID_DIGITS
+    ),
+    regex.VERBOSE
 )
 
-CASIZ_FALLBACK_REGEX = regex.compile(r'(?i)(?:CASIZ|CAS)[\s_#-]*(\d{3,12})(?!\d)')
+
+CASIZ_FALLBACK_REGEX = regex.compile(
+    r'(?i)(?:CASIZ|CAS)[\s_#-]*(\d{{{min_digits},{max_digits}}})(?!\d)'.format(
+        min_digits=MINIMUM_ID_DIGITS_WITH_PREFIX,
+        max_digits=MAXIMUM_ID_DIGITS
+    )
+)

--- a/config_files/iz_config.unittest.py
+++ b/config_files/iz_config.unittest.py
@@ -10,26 +10,12 @@ PASSWORD = '123pass'
 
 REPORT_PATH = f"html_reports{sla}iz_import_monitoring.html"
 COLLECTION_NAME = "IZ"
-MINIMUM_ID_DIGITS = 5
-MAXIMUM_ID_DIGITS = 12
 
 AGENT_ID = 123456
 
 # path variables
-MINIMUM_ID_DIGITS = 5
-MAXIMUM_ID_DIGITS = 10
-SHORT_MINIMUM_ID_DIGITS = 3
 IMAGE_EXTENSION = r'(\.(jpg|jpeg|tiff|tif|png|dng))$'
 IMAGE_SUFFIX = rf'[a-z\-\(\)0-9 ©_,.]*{IMAGE_EXTENSION}'
-CASIZ_NUMBER = '([0-9]{' + str(MINIMUM_ID_DIGITS) + ','+ str(MAXIMUM_ID_DIGITS)+'})'
-CASIZ_NUMBER_SHORT = '([0-9]{' + str(SHORT_MINIMUM_ID_DIGITS) + ','+ str(MAXIMUM_ID_DIGITS)+'})'
-CASIZ_PREFIX = r'cas(iz)?[#a-z _]*[_ \-]?'
-CASIZ_MATCH = rf'({CASIZ_PREFIX}{CASIZ_NUMBER_SHORT})|({CASIZ_NUMBER})'
-CASIZ_NUMBER_EXACT = rf'{CASIZ_PREFIX}([0-9]+)'
-FILENAME_MATCH = rf'{CASIZ_MATCH}{IMAGE_SUFFIX}'
-FILENAME_CONJUNCTION_MATCH = rf'(({CASIZ_MATCH})|([ ]*(and|or)[ ]*({CASIZ_MATCH})))+'
-DIRECTORY_CONJUNCTION_MATCH = FILENAME_CONJUNCTION_MATCH
-DIRECTORY_MATCH = rf'{CASIZ_MATCH}'
 
 REPORT_PATH = f"html_reports{sla}iz_import_monitoring.html"
 # summary statistics, figures to configure html report
@@ -44,17 +30,17 @@ CASIZ_NUMBER_REGEX = regex.compile(
     (?<!\w)                         # No word character before
     (                               
       (?:
-        (?!IZACC[\s_-]?)             # Not IZACC prefix (negative lookahead)
+        (?!IZACC[\s_#-]?)             # Not IZACC prefix (negative lookahead)
         (?P<prefix>CASIZ|CAS)        # CASIZ or CAS (named group 'prefix')
-        (?:[\s_-]*)                  # Spaces, underscores, dashes (zero or more)
+        (?:[\s_#-]*)                  # Spaces, underscores, dashes (zero or more)
       )?
       (?P<number>                    # --- Capture only the number ---
         (?!
           (?:DSC|P)\d{3,}            # Not digital camera serials
         )
         (?!
-          (?<!CASIZ[\s_-]*|CAS[\s_-]*) # unless CASIZ/CAS prefix
-          (?:19|20)\d{6}             # Dates like 20230412
+          (?<!CASIZ[\s_#-]*|CAS[\s_#-]*) # unless CASIZ/CAS prefix
+          (?:(1[6-9]\d{2}|20\d{2})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))             # Dates like 20230412
         )
         \d{3,12}                     # 3-12 digits
       )
@@ -62,9 +48,9 @@ CASIZ_NUMBER_REGEX = regex.compile(
     (?(prefix)                       # If prefix matched:
         (?=\D|$)                     # allow anything non-digit or end
     |
-        (?=\b|[_\s-]|$)              # else must have boundary
+        (?=\b|[_\s#-]|$)              # else must have boundary
     )
     ''', regex.VERBOSE
 )
 
-CASIZ_FALLBACK_REGEX = regex.compile(r'(?i)(?:CASIZ|CAS)[\s_-]*(\d{3,12})(?!\d)')
+CASIZ_FALLBACK_REGEX = regex.compile(r'(?i)(?:CASIZ|CAS)[\s_#-]*(\d{3,12})(?!\d)')

--- a/config_files/iz_config.unittest.py
+++ b/config_files/iz_config.unittest.py
@@ -1,4 +1,5 @@
 from os import path
+import regex
 sla = path.sep
 # database credentials
 SPECIFY_DATABASE_HOST = '127.0.0.1'
@@ -37,3 +38,33 @@ MAILING_LIST = []
 SUMMARY_TERMS = []
 SUMMARY_IMG = []
 
+CASIZ_NUMBER_REGEX = regex.compile(
+    r'''
+    (?ix)                           # Ignore case, allow comments
+    (?<!\w)                         # No word character before
+    (                               
+      (?:
+        (?!IZACC[\s_-]?)             # Not IZACC prefix (negative lookahead)
+        (?P<prefix>CASIZ|CAS)        # CASIZ or CAS (named group 'prefix')
+        (?:[\s_-]*)                  # Spaces, underscores, dashes (zero or more)
+      )?
+      (?P<number>                    # --- Capture only the number ---
+        (?!
+          (?:DSC|P)\d{3,}            # Not digital camera serials
+        )
+        (?!
+          (?<!CASIZ[\s_-]*|CAS[\s_-]*) # unless CASIZ/CAS prefix
+          (?:19|20)\d{6}             # Dates like 20230412
+        )
+        \d{3,12}                     # 3-12 digits
+      )
+    )
+    (?(prefix)                       # If prefix matched:
+        (?=\D|$)                     # allow anything non-digit or end
+    |
+        (?=\b|[_\s-]|$)              # else must have boundary
+    )
+    ''', regex.VERBOSE
+)
+
+CASIZ_FALLBACK_REGEX = regex.compile(r'(?i)(?:CASIZ|CAS)[\s_-]*(\d{3,12})(?!\d)')

--- a/config_files/iz_config.unittest.py
+++ b/config_files/iz_config.unittest.py
@@ -24,6 +24,10 @@ MAILING_LIST = []
 SUMMARY_TERMS = []
 SUMMARY_IMG = []
 
+MINIMUM_ID_DIGITS_WITH_PREFIX = 3
+MAXIMUM_ID_DIGITS = 12
+MINIMUM_ID_DIGITS = 5
+
 CASIZ_NUMBER_REGEX = regex.compile(
     r'''
     (?ix)                           # Ignore case, allow comments
@@ -36,21 +40,31 @@ CASIZ_NUMBER_REGEX = regex.compile(
       )?
       (?P<number>                    # --- Capture only the number ---
         (?!
-          (?:DSC|P)\d{3,}            # Not digital camera serials
+          (?:DSC|P)\d{{{min_digits_with_prefix},}}     # Not camera serials
         )
         (?!
-          (?<!CASIZ[\s_#-]*|CAS[\s_#-]*) # unless CASIZ/CAS prefix
-          (?:(1[6-9]\d{2}|20\d{2})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01]))             # Dates like 20230412
+          (?<!CASIZ[\s_#-]*|CAS[\s_#-]*)
+          (?:(?:19|20)\d{{2}}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01]))
         )
-        \d{3,12}                     # 3-12 digits
+        \d{{{min_digits_with_prefix},{max_digits}}}
       )
     )
-    (?(prefix)                       # If prefix matched:
-        (?=\D|$)                     # allow anything non-digit or end
+    (?(prefix)
+        (?=\D|$)
     |
-        (?=\b|[_\s#-]|$)              # else must have boundary
+        (?=\b|[_\s#-]|$)
     )
-    ''', regex.VERBOSE
+    '''.format(
+        min_digits_with_prefix=MINIMUM_ID_DIGITS_WITH_PREFIX,
+        max_digits=MAXIMUM_ID_DIGITS
+    ),
+    regex.VERBOSE
 )
 
-CASIZ_FALLBACK_REGEX = regex.compile(r'(?i)(?:CASIZ|CAS)[\s_#-]*(\d{3,12})(?!\d)')
+
+CASIZ_FALLBACK_REGEX = regex.compile(
+    r'(?i)(?:CASIZ|CAS)[\s_#-]*(\d{{{min_digits},{max_digits}}})(?!\d)'.format(
+        min_digits=MINIMUM_ID_DIGITS_WITH_PREFIX,
+        max_digits=MAXIMUM_ID_DIGITS
+    )
+)

--- a/docs/iz_importer_casiz.md
+++ b/docs/iz_importer_casiz.md
@@ -104,28 +104,32 @@ This is the **main** search rule.
    - If a "CAS" or "CASIZ" prefix is present, anything can follow the number (letters, symbols, etc.).
    - If there’s **no prefix**, the number must end cleanly (with a space, dash, underscore, `#`, or end of text).
 
-# 🧩 CASIZ Number Extraction Flow
+# 🧩 CASIZ Number Extraction Flow (Corrected)
 
 ```mermaid
 flowchart TD
-    A[Start] --> B{Is there a CASIZ or CAS before the number?}
-    B -- Yes --> C{Camera Serial Pattern: DSCxxxx or Pxxxx?}
-    B -- No --> F{Camera Serial Pattern: DSCxxxx or Pxxxx?}
+    A[Start] --> B{Is there an IZACC prefix?}
+    B -- Yes --> D[[Ignore match]]
+    B -- No --> C{Is there a CASIZ or CAS before the number?}
     
-    C -- Yes --> D[[Ignore match]]
-    C -- No --> E{Date Pattern: e.g. 20230412?}
+    C -- Yes --> E{Camera Serial Pattern: DSCxxxx or Pxxxx?}
+    C -- No --> F{Camera Serial Pattern: DSCxxxx or Pxxxx?}
+    
+    E -- Yes --> D
+    E -- No --> G{Date Pattern: e.g. 20230412?}
 
     F -- Yes --> D
-    F -- No --> E
+    F -- No --> G
 
-    E -- No --> G[[Accept match]]
-    E -- Yes --> H{Is there a CASIZ/CAS prefix?}
+    G -- No --> H[[Accept match]]
+    G -- Yes --> I{Is there a CASIZ/CAS prefix?}
 
-    H -- Yes --> G
-    H -- No --> D
+    I -- Yes --> H
+    I -- No --> D
 
     style D fill:#ffdddd,stroke:#ff0000,stroke-width:2px
-    style G fill:#ddffdd,stroke:#00aa00,stroke-width:2px
+    style H fill:#ddffdd,stroke:#00aa00,stroke-width:2px
+
 
 ```
 

--- a/docs/iz_importer_casiz.md
+++ b/docs/iz_importer_casiz.md
@@ -104,17 +104,16 @@ This is the **main** search rule.
    - If a "CAS" or "CASIZ" prefix is present, anything can follow the number (letters, symbols, etc.).
    - If there’s **no prefix**, the number must end cleanly (with a space, dash, underscore, `#`, or end of text).
 
-
 # 🧩 CASIZ Number Extraction Flow
 
 ```mermaid
 flowchart TD
     A[Start] --> B{Is there a CASIZ or CAS before the number?}
-    B -- Yes --> C{Camera Serial Pattern (DSCxxxx or Pxxxx)?}
-    B -- No --> F{Camera Serial Pattern (DSCxxxx or Pxxxx)?}
+    B -- Yes --> C{Camera Serial Pattern \(DSCxxxx or Pxxxx\)?}
+    B -- No --> F{Camera Serial Pattern \(DSCxxxx or Pxxxx\)?}
     
     C -- Yes --> D[Ignore match (stop)]
-    C -- No --> E{Date Pattern (e.g., 20230412)?}
+    C -- No --> E{Date Pattern \(e.g., 20230412\)?}
 
     F -- Yes --> D
     F -- No --> E
@@ -124,6 +123,7 @@ flowchart TD
 
     H -- Yes --> G
     H -- No --> D
+```
 
 ---
 

--- a/docs/iz_importer_casiz.md
+++ b/docs/iz_importer_casiz.md
@@ -31,8 +31,9 @@ If all three stages fail:
 This is the main entry point for CASIZ extraction. It performs a **sequential attempt** to find CASIZ data from three potential sources by the following order:
 
 - First it will look into the **image filename** (see 2.1)
-- Then it will look into the **EXIF metadata** (see 2.2)
-- Last it will look into the **directory name** (see 2.3)
+- Then it will look into the **directory name** (see 2.2)
+- Last it will look into the **EXIF metadata** (see 2.3)
+
 
 > ⚠️ **Important:**  
 > The process stops immediately once a match is found in any step.  
@@ -48,9 +49,15 @@ This function checks whether the **base filename** contains any recognizable CAS
 
 ---
 
-### 2.2. 🧾 `get_casiz_from_exif`
+### 2.2 📂 `attempt_directory_match`
 
-If the filename match fails, this function tries to extract a CASIZ ID from the image's **EXIF metadata** (e.g., description or title fields).
+If filename match fails, the importer attempts to extract CASIZ ID from the **directory path** containing the image.
+
+---
+
+### 2.3 🧾 `get_casiz_from_exif`
+
+If both the filename and directory match fail, this function tries to extract a CASIZ ID from the image's **EXIF metadata** (e.g., description or title fields).
 
 It will try to extract casiz from the following fields: (see metadata repo for more details on those constant definitions)
 
@@ -61,14 +68,9 @@ It will try to extract casiz from the following fields: (see metadata repo for m
 | EXIFConstants.XMP_LR_HIERARCHICAL_SUBJECT |
 | EXIFConstants.IPTC_CAPTION_ABSTRACT |
 | EXIFConstants.XMP_DC_DESCRIPTION |
+| XMP:Description |
 | EXIFConstants.EXIF_IFD0_IMAGE_DESCRIPTION |
 | EXIFConstants.XMP_TITLE |
-
----
-
-### 2.3 📂 `attempt_directory_match`
-
-If both filename and EXIF methods fail, the importer attempts to extract CASIZ ID from the **directory path** containing the image.
 
 ---
 
@@ -76,11 +78,52 @@ If both filename and EXIF methods fail, the importer attempts to extract CASIZ I
 
 ✅ Following pattern will be used to extrac CASIZ:
 
-1. if there is `cas` or `casiz` (case insensitive) in the string **before** consecutive digits
-   1. if digits are longer than 3: take up to 10 digits as CASIZ, otherwise go to next rule
-   2. there can be other characters between the digits and `cas/casiz`, but not between the digits 
-2. if consecutive digits is more than 5. take up to 10 digits as CASIZ
-3. there can be more than 1 matches
+This is the **main** search rule.
+
+### Step-by-Step:
+
+1. **Not inside a word**  
+   - The match must not be inside another word (e.g., `mycas123` won't match).
+
+2. **Look for CASIZ or CAS (optional)**  
+   - Searches for "CASIZ" or "CAS" (case-insensitive: "casiz", "Cas" are fine).
+   - Allows spaces, underscores `_`, dashes `-`, or `#` between the word and the number.
+     - Example matches: `CAS_1234`, `cas-1234`, `casiz#1234`.
+
+3. **Skip fake matches (IZACC)**  
+   - If `IZACC` comes before the number, it is **ignored**.
+
+4. **Check the number itself**  
+   - Must be a **3 to 12 digit** number.
+   - Must **not** match camera serial number patterns:
+     - Nikon: `DSC1234`
+     - Olympus: `P1234`
+   - Must **not** look like a date (e.g., `20230412`), **unless** it has a CAS or CASIZ prefix.
+
+5. **Finish carefully**
+   - If a "CAS" or "CASIZ" prefix is present, anything can follow the number (letters, symbols, etc.).
+   - If there’s **no prefix**, the number must end cleanly (with a space, dash, underscore, `#`, or end of text).
+
+
+# 🧩 CASIZ Number Extraction Flow
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Is there a CASIZ or CAS before the number?}
+    B -- Yes --> C{Camera Serial Pattern (DSCxxxx or Pxxxx)?}
+    B -- No --> F{Camera Serial Pattern (DSCxxxx or Pxxxx)?}
+    
+    C -- Yes --> D[Ignore match (stop)]
+    C -- No --> E{Date Pattern (e.g., 20230412)?}
+
+    F -- Yes --> D
+    F -- No --> E
+
+    E -- No --> G[Accept match]
+    E -- Yes --> H{Is there a CASIZ/CAS prefix?}
+
+    H -- Yes --> G
+    H -- No --> D
 
 ---
 

--- a/docs/iz_importer_casiz.md
+++ b/docs/iz_importer_casiz.md
@@ -109,20 +109,24 @@ This is the **main** search rule.
 ```mermaid
 flowchart TD
     A[Start] --> B{Is there a CASIZ or CAS before the number?}
-    B -- Yes --> C{Camera Serial Pattern \(DSCxxxx or Pxxxx\)?}
-    B -- No --> F{Camera Serial Pattern \(DSCxxxx or Pxxxx\)?}
+    B -- Yes --> C{Camera Serial Pattern: DSCxxxx or Pxxxx?}
+    B -- No --> F{Camera Serial Pattern: DSCxxxx or Pxxxx?}
     
-    C -- Yes --> D[Ignore match (stop)]
-    C -- No --> E{Date Pattern \(e.g., 20230412\)?}
+    C -- Yes --> D[[Ignore match (stop)]]
+    C -- No --> E{Date Pattern: e.g. 20230412?}
 
     F -- Yes --> D
     F -- No --> E
 
-    E -- No --> G[Accept match]
+    E -- No --> G[[Accept match]]
     E -- Yes --> H{Is there a CASIZ/CAS prefix?}
 
     H -- Yes --> G
     H -- No --> D
+
+    style D fill:#ffdddd,stroke:#ff0000,stroke-width:2px
+    style G fill:#ddffdd,stroke:#00aa00,stroke-width:2px
+
 ```
 
 ---

--- a/docs/iz_importer_casiz.md
+++ b/docs/iz_importer_casiz.md
@@ -68,7 +68,7 @@ It will try to extract casiz from the following fields: (see metadata repo for m
 | EXIFConstants.XMP_LR_HIERARCHICAL_SUBJECT |
 | EXIFConstants.IPTC_CAPTION_ABSTRACT |
 | EXIFConstants.XMP_DC_DESCRIPTION |
-| XMP:Description |
+| EXIFConstants.XMP:Description |
 | EXIFConstants.EXIF_IFD0_IMAGE_DESCRIPTION |
 | EXIFConstants.XMP_TITLE |
 

--- a/docs/iz_importer_casiz.md
+++ b/docs/iz_importer_casiz.md
@@ -112,7 +112,7 @@ flowchart TD
     B -- Yes --> C{Camera Serial Pattern: DSCxxxx or Pxxxx?}
     B -- No --> F{Camera Serial Pattern: DSCxxxx or Pxxxx?}
     
-    C -- Yes --> D[[Ignore match (stop)]]
+    C -- Yes --> D[[Ignore match]]
     C -- No --> E{Date Pattern: e.g. 20230412?}
 
     F -- Yes --> D

--- a/iz_importer.py
+++ b/iz_importer.py
@@ -280,7 +280,7 @@ class IzImporter(Importer):
             EXIFConstants.XMP_DC_SUBJECT,
             EXIFConstants.XMP_LR_HIERARCHICAL_SUBJECT,
             EXIFConstants.IPTC_CAPTION_ABSTRACT,
-            EXIFConstants.XMP_DESCRIPTION
+            EXIFConstants.XMP_DESCRIPTION,
             EXIFConstants.XMP_DC_DESCRIPTION,
             EXIFConstants.EXIF_IFD0_IMAGE_DESCRIPTION,
             EXIFConstants.XMP_TITLE,

--- a/iz_importer.py
+++ b/iz_importer.py
@@ -210,12 +210,14 @@ class IzImporter(Importer):
                 continue
 
             if prefix:
-                if not (3 <= valid_length <= 12):
+                if not (self.iz_importer_config.MINIMUM_ID_DIGITS_WITH_PREFIX <=
+                        valid_length <= self.iz_importer_config.MAXIMUM_ID_DIGITS):
                     pos = number_end
                     last_prefix_match_end = number_end
                     continue
             else:
-                if not (5 <= valid_length <= 12):
+                if not (self.iz_importer_config.MINIMUM_ID_DIGITS <=
+                        valid_length <= self.iz_importer_config.MAXIMUM_ID_DIGITS):
                     pos = number_end
                     last_prefix_match_end = number_end
                     continue

--- a/iz_importer.py
+++ b/iz_importer.py
@@ -280,8 +280,7 @@ class IzImporter(Importer):
             EXIFConstants.XMP_DC_SUBJECT,
             EXIFConstants.XMP_LR_HIERARCHICAL_SUBJECT,
             EXIFConstants.IPTC_CAPTION_ABSTRACT,
-            "XMP:Description",
-            # cas_metadata_tools 1.0.0 has this key as "XMP-dc:Description" for some reason
+            EXIFConstants.XMP_DESCRIPTION
             EXIFConstants.XMP_DC_DESCRIPTION,
             EXIFConstants.EXIF_IFD0_IMAGE_DESCRIPTION,
             EXIFConstants.XMP_TITLE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,6 @@ pandas~=2.2.3
 faker~=18.11.2
 pillow~=10.3.0
 retrying~=1.3.4
-cas_metadata_tools~=1.0.0
+cas_metadata_tools~=1.0.1
 regex~=2024.11.6
 testfixtures

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,4 +57,5 @@ faker~=18.11.2
 pillow~=10.3.0
 retrying~=1.3.4
 cas_metadata_tools~=1.0.0
+regex~=2024.11.6
 testfixtures

--- a/tests/iz_importer_tests/iz_test_images_mock_data.json
+++ b/tests/iz_importer_tests/iz_test_images_mock_data.json
@@ -64,9 +64,7 @@
       "size": 43942,
       "modified": "2025-03-26T16:24:43",
       "casiz": {
-        "from_filename": [
-          58617
-        ],
+        "from_filename": null,
         "from_exif": [
           58617
         ],
@@ -121,7 +119,6 @@
       "modified": "2025-03-26T16:24:43",
       "casiz": {
         "from_filename": [
-          73756,
           190941
         ],
         "from_exif": [
@@ -558,10 +555,7 @@
       "size": 47492,
       "modified": "2025-03-26T16:24:46",
       "casiz": {
-        "from_filename": [
-          125033,
-          20220429
-        ],
+        "from_filename": null,
         "from_exif": [
           125033,
           20220429
@@ -1103,9 +1097,7 @@
       "size": 31906,
       "modified": "2025-03-26T16:24:50",
       "casiz": {
-        "from_filename": [
-          41562023
-        ],
+        "from_filename": null,
         "from_exif": [
           215909,
           93935
@@ -1162,12 +1154,9 @@
       "size": 34683,
       "modified": "2025-03-26T16:24:51",
       "casiz": {
-        "from_filename": [
-          62023
-        ],
+        "from_filename": null,
         "from_exif": [
-          215909,
-          93935
+          215909
         ],
         "from_directory": [
           429836
@@ -1321,10 +1310,7 @@
       "size": 32012,
       "modified": "2025-03-26T16:24:53",
       "casiz": {
-        "from_filename": [
-          30600,
-          201610
-        ],
+        "from_filename": null,
         "from_exif": [
           217699
         ],
@@ -1338,8 +1324,7 @@
         "from_exif": "© Christina N. Piotrowski licensed under CC BY-NC-SA"
       },
       "metadata": {},
-      "copyright_source": "exif",
-      "skip_test": true
+      "copyright_source": "exif"
     },
     "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2015/CASIZ 214715_VIP2015__2015_04_14_3666.JPG": {
       "path": "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2015/CASIZ 214715_VIP2015__2015_04_14_3666.JPG",
@@ -1924,8 +1909,7 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1964,8 +1948,7 @@
           "Daniel Killam"
         ]
       },
-      "copyright_source": "file key",
-      "skip_test": true
+      "copyright_source": "file key"
     },
     "iz_test_images/Vanessa Guerra/CASIZ 185570 Myxicola_IMG_20110210_105637.jpg": {
       "path": "iz_test_images/Vanessa Guerra/CASIZ 185570 Myxicola_IMG_20110210_105637.jpg",
@@ -1978,13 +1961,10 @@
       "modified": "2025-03-26T16:24:59",
       "casiz": {
         "from_filename": [
-          185570,
-          105637,
-          20110210
+          185570
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -3012,8 +2992,7 @@
       "modified": "2025-03-26T16:25:07",
       "casiz": {
         "from_filename": [
-          241666,
-          882
+          241666
         ],
         "from_exif": [
           65098
@@ -3067,7 +3046,6 @@
       "modified": "2025-03-26T16:25:08",
       "casiz": {
         "from_filename": [
-          2016082416,
           218811
         ],
         "from_exif": [
@@ -4121,7 +4099,8 @@
           "FALSE"
         ]
       },
-      "copyright_source": "file key"
+      "copyright_source": "file key",
+      "skip_test": true
     },
     "iz_test_images/Rich Mooi/CASIZ 186310 Caymanostellid composite.jpg": {
       "path": "iz_test_images/Rich Mooi/CASIZ 186310 Caymanostellid composite.jpg",
@@ -4189,7 +4168,6 @@
       "modified": "2025-03-26T16:25:16",
       "casiz": {
         "from_filename": [
-          3301433,
           234658
         ],
         "from_exif": [
@@ -4244,8 +4222,7 @@
       "modified": "2025-03-26T16:25:17.324508",
       "casiz": {
         "from_filename": [
-          241488,
-          160218
+          241488
         ],
         "from_exif": [
           65098

--- a/tests/iz_importer_tests/iz_test_images_mock_data.json
+++ b/tests/iz_importer_tests/iz_test_images_mock_data.json
@@ -106,7 +106,8 @@
         ]
       },
       "copyright_source": "file key",
-      "attachment_id": 234
+      "attachment_id": 234,
+      "skip_test": true
     },
     "iz_test_images/Nathan Hollenbeck/CASIZ 190941 Clade II RBRF12 male PB073756 c N Hollenbeck.JPG": {
       "path": "iz_test_images/Nathan Hollenbeck/CASIZ 190941 Clade II RBRF12 male PB073756 c N Hollenbeck.JPG",
@@ -122,7 +123,6 @@
           190941
         ],
         "from_exif": [
-          73756,
           190941
         ],
         "from_directory": null,
@@ -556,12 +556,9 @@
       "modified": "2025-03-26T16:24:46",
       "casiz": {
         "from_filename": null,
-        "from_exif": [
-          125033,
-          20220429
-        ],
+        "from_exif": null,
         "from_directory": null,
-        "from": "Filename"
+        "from": null
       },
       "copyright": {
         "from_directory": "",
@@ -826,8 +823,7 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          215909,
-          93935
+          215909
         ],
         "from_directory": null,
         "from": "EXIF"
@@ -882,8 +878,7 @@
           300001
         ],
         "from_exif": [
-          215909,
-          93935
+          215909
         ],
         "from_directory": null,
         "from": "Filename"
@@ -938,8 +933,7 @@
           202356
         ],
         "from_exif": [
-          215909,
-          93935
+          215909
         ],
         "from_directory": null,
         "from": "Filename"
@@ -994,8 +988,7 @@
           9535
         ],
         "from_exif": [
-          215909,
-          93935
+          215909
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1099,11 +1092,10 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          215909,
-          93935
+          215909
         ],
         "from_directory": null,
-        "from": "Filename"
+        "from": "EXIF"
       },
       "copyright": {
         "from_directory": null,
@@ -1161,7 +1153,7 @@
         "from_directory": [
           429836
         ],
-        "from": "Filename"
+        "from": "Directory"
       },
       "copyright": {
         "from_directory": null,
@@ -1180,7 +1172,7 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          62023
+          185568
         ],
         "from_directory": null,
         "from": "EXIF"
@@ -1233,11 +1225,9 @@
       "modified": "2025-03-26T16:24:52",
       "casiz": {
         "from_filename": null,
-        "from_exif": [
-          76110
-        ],
+        "from_exif": null,
         "from_directory": null,
-        "from": "EXIF"
+        "from": null
       },
       "copyright": {
         "from_directory": null,
@@ -1317,7 +1307,7 @@
         "from_directory": [
           219416
         ],
-        "from": "Filename"
+        "from": "Directory"
       },
       "copyright": {
         "from_directory": null,
@@ -1340,8 +1330,7 @@
           214715
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1395,13 +1384,12 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          83993,
           214567
         ],
         "from_directory": [
           214568
         ],
-        "from": "EXIF"
+        "from": "Directory"
       },
       "copyright": {
         "from_directory": null,
@@ -1420,8 +1408,7 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "EXIF"
@@ -1471,8 +1458,7 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "EXIF"
@@ -1522,8 +1508,7 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "EXIF"
@@ -1577,8 +1562,7 @@
           97438
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1632,8 +1616,7 @@
           185403
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1687,8 +1670,7 @@
           116217
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1744,8 +1726,7 @@
           184714
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1800,8 +1781,7 @@
           65116
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1855,8 +1835,7 @@
           111359
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -1912,7 +1891,7 @@
           214715
         ],
         "from_directory": null,
-        "from": "Filename"
+        "from": "EXIF"
       },
       "copyright": {
         "from_directory": null,
@@ -2018,8 +1997,7 @@
           185407
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -2074,8 +2052,7 @@
           105040
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -2129,8 +2106,7 @@
           190941
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -2184,8 +2160,7 @@
           192393
         ],
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "Filename"
@@ -2235,8 +2210,7 @@
       "casiz": {
         "from_filename": null,
         "from_exif": [
-          214715,
-          83487
+          214715
         ],
         "from_directory": null,
         "from": "EXIF"
@@ -3328,7 +3302,7 @@
         "from_directory": [
           60451
         ],
-        "from": "EXIF"
+        "from": "Directory"
       },
       "copyright": {
         "from_directory": "CAS",
@@ -3384,7 +3358,7 @@
         "from_directory": [
           63814
         ],
-        "from": "EXIF"
+        "from": "Directory"
       },
       "copyright": {
         "from_directory": "CAS",

--- a/tests/iz_importer_tests/iz_test_images_mock_data.json
+++ b/tests/iz_importer_tests/iz_test_images_mock_data.json
@@ -59,11 +59,9 @@
       "modified": "2025-03-26T16:24:43",
       "casiz": {
         "from_filename": null,
-        "from_exif": [
-          58617
-        ],
+        "from_exif": null,
         "from_directory": null,
-        "from": "Filename"
+        "from": null
       },
       "copyright": {
         "from_directory": "CAS",
@@ -100,8 +98,7 @@
         ]
       },
       "copyright_source": "file key",
-      "attachment_id": 234,
-      "skip_test": true
+      "attachment_id": 234
     },
     "iz_test_images/Nathan Hollenbeck/CASIZ 190941 Clade II RBRF12 male PB073756 c N Hollenbeck.JPG": {
       "path": "iz_test_images/Nathan Hollenbeck/CASIZ 190941 Clade II RBRF12 male PB073756 c N Hollenbeck.JPG",
@@ -2260,7 +2257,7 @@
           190479
         ],
         "from_directory": null,
-        "from": "Filename"
+        "from": "EXIF"
       },
       "copyright": {
         "from_directory": null,
@@ -2295,8 +2292,7 @@
           "Mikihito Arai"
         ]
       },
-      "copyright_source": "file key",
-      "skip_test": true
+      "copyright_source": "file key"
     },
     "iz_test_images/Victor Smith copyright CAS/CASIZ171855_D.JPG": {
       "path": "iz_test_images/Victor Smith copyright CAS/CASIZ171855_D.JPG",
@@ -3877,8 +3873,7 @@
           "FALSE"
         ]
       },
-      "copyright_source": "file key",
-      "skip_test": true
+      "copyright_source": "file key"
     },
     "iz_test_images/Rich Mooi/CASIZ 186310 Caymanostellid composite.jpg": {
       "path": "iz_test_images/Rich Mooi/CASIZ 186310 Caymanostellid composite.jpg",

--- a/tests/iz_importer_tests/iz_test_images_mock_data.json
+++ b/tests/iz_importer_tests/iz_test_images_mock_data.json
@@ -3,9 +3,6 @@
     "iz_test_images/Ashley Kidd copyright Ashley Kidd/CASIZ_117433_AKidd.jpeg": {
       "path": "iz_test_images/Ashley Kidd copyright Ashley Kidd/CASIZ_117433_AKidd.jpeg",
       "extension": ".jpeg",
-      "casiz_numbers": [
-        117433
-      ],
       "has_key_file": true,
       "size": 37164,
       "modified": "2025-03-26T16:24:42",
@@ -57,9 +54,6 @@
     "iz_test_images/Robert Van Syoc Copyright CAS/058617IZ bottom.jpg": {
       "path": "iz_test_images/Robert Van Syoc Copyright CAS/058617IZ bottom.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        58617
-      ],
       "has_key_file": true,
       "size": 43942,
       "modified": "2025-03-26T16:24:43",
@@ -112,9 +106,6 @@
     "iz_test_images/Nathan Hollenbeck/CASIZ 190941 Clade II RBRF12 male PB073756 c N Hollenbeck.JPG": {
       "path": "iz_test_images/Nathan Hollenbeck/CASIZ 190941 Clade II RBRF12 male PB073756 c N Hollenbeck.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        190941
-      ],
       "has_key_file": true,
       "size": 29292,
       "modified": "2025-03-26T16:24:43",
@@ -167,7 +158,6 @@
     "iz_test_images/Zyanya Mora Vallin Copyright CAS/IMG_8870.JPG": {
       "path": "iz_test_images/Zyanya Mora Vallin Copyright CAS/IMG_8870.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 20060,
       "modified": "2025-03-26T16:24:43",
@@ -218,9 +208,6 @@
     "iz_test_images/Neil Fahy/CASIZ 058827 V1158A.jpg": {
       "path": "iz_test_images/Neil Fahy/CASIZ 058827 V1158A.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        58827
-      ],
       "has_key_file": true,
       "size": 26962,
       "modified": "2025-03-26T16:24:44",
@@ -272,9 +259,6 @@
     "iz_test_images/Christine Garcia Copyright CAS/43985_B,Radius4,Smoothing1_2.tif": {
       "path": "iz_test_images/Christine Garcia Copyright CAS/43985_B,Radius4,Smoothing1_2.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        43985
-      ],
       "has_key_file": true,
       "size": 34582,
       "modified": "2025-03-26T16:24:44",
@@ -327,9 +311,6 @@
     "iz_test_images/Rachel Quock Copyright CAS/CAS 005707 Schizobopyrina bombyliaster HOLOTYPE dorsal.tif": {
       "path": "iz_test_images/Rachel Quock Copyright CAS/CAS 005707 Schizobopyrina bombyliaster HOLOTYPE dorsal.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        5707
-      ],
       "has_key_file": true,
       "size": 34724,
       "modified": "2025-03-26T16:24:45",
@@ -382,9 +363,6 @@
     "iz_test_images/Robert Van Syoc/198185 AND 214318 VS.jpg": {
       "path": "iz_test_images/Robert Van Syoc/198185 AND 214318 VS.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        198185
-      ],
       "has_key_file": true,
       "size": 34631,
       "modified": "2025-03-26T16:24:45",
@@ -439,7 +417,6 @@
     "iz_test_images/Barbara Andrews/Barbara in the Joaquin Rocks hole (3).jpg": {
       "path": "iz_test_images/Barbara Andrews/Barbara in the Joaquin Rocks hole (3).jpg",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 30940,
       "modified": "2025-03-26T16:24:46",
@@ -492,9 +469,6 @@
     "iz_test_images/Jackie Sones/Dosima_fascicularis CASIZ 202357.jpg": {
       "path": "iz_test_images/Jackie Sones/Dosima_fascicularis CASIZ 202357.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        202357
-      ],
       "has_key_file": true,
       "size": 28672,
       "modified": "2025-03-26T16:24:46",
@@ -547,10 +521,6 @@
     "iz_test_images/Credit unknown_CAS copyright_NOT photoslide scan/20220429_125033.jpg": {
       "path": "iz_test_images/Credit unknown_CAS copyright_NOT photoslide scan/20220429_125033.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        220429,
-        125033
-      ],
       "has_key_file": true,
       "size": 47492,
       "modified": "2025-03-26T16:24:46",
@@ -598,9 +568,6 @@
     "iz_test_images/Hanna Baek_not types/CASIZ 120138 Acesta sp. R valve Credit Hanna Baek.jpg": {
       "path": "iz_test_images/Hanna Baek_not types/CASIZ 120138 Acesta sp. R valve Credit Hanna Baek.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        120138
-      ],
       "has_key_file": true,
       "size": 47613,
       "modified": "2025-03-26T16:24:47",
@@ -653,9 +620,6 @@
     "iz_test_images/William Newman/CASIZ 219741Traite Illustrations.pdf737 (1)_recd from W Newman.tiff": {
       "path": "iz_test_images/William Newman/CASIZ 219741Traite Illustrations.pdf737 (1)_recd from W Newman.tiff",
       "extension": ".tiff",
-      "casiz_numbers": [
-        219741
-      ],
       "has_key_file": true,
       "size": 47558,
       "modified": "2025-03-26T16:24:47",
@@ -707,9 +671,6 @@
     "iz_test_images/Credit Unknown copyright CAS Photoslide Scans/CASIZ 009736 Dendronephthia (Morchellana) S598 Credit Unknown.tif": {
       "path": "iz_test_images/Credit Unknown copyright CAS Photoslide Scans/CASIZ 009736 Dendronephthia (Morchellana) S598 Credit Unknown.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        9736
-      ],
       "has_key_file": true,
       "size": 47616,
       "modified": "2025-03-26T16:24:48",
@@ -761,9 +722,6 @@
     "iz_test_images/Allyn G. Smith/CASIZ 061603 Janaria mirabilis S490 Credit A.G. Smith.tif": {
       "path": "iz_test_images/Allyn G. Smith/CASIZ 061603 Janaria mirabilis S490 Credit A.G. Smith.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        61603
-      ],
       "has_key_file": true,
       "size": 47647,
       "modified": "2025-03-26T16:24:48",
@@ -816,7 +774,6 @@
     "iz_test_images/Kelly Markello/DSC_0001.JPG": {
       "path": "iz_test_images/Kelly Markello/DSC_0001.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 34891,
       "modified": "2025-03-26T16:24:48",
@@ -867,9 +824,6 @@
     "iz_test_images/Coral Reef Research Foundation/CASIZ 300001.jpg": {
       "path": "iz_test_images/Coral Reef Research Foundation/CASIZ 300001.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        300001
-      ],
       "has_key_file": true,
       "size": 34951,
       "modified": "2025-03-26T16:24:49",
@@ -922,9 +876,6 @@
     "iz_test_images/Eric Sanford/CASIZ 202356 Hyalocylis_striata_shell_Sanford1.jpg": {
       "path": "iz_test_images/Eric Sanford/CASIZ 202356 Hyalocylis_striata_shell_Sanford1.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        202356
-      ],
       "has_key_file": true,
       "size": 32034,
       "modified": "2025-03-26T16:24:49",
@@ -977,9 +928,6 @@
     "iz_test_images/Daphne Fautin Dunn_Photoslide scans/CASIZ 009535 Stichodactyla haddoni S891 Credit Daphne F Dunn.tif": {
       "path": "iz_test_images/Daphne Fautin Dunn_Photoslide scans/CASIZ 009535 Stichodactyla haddoni S891 Credit Daphne F Dunn.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        9535
-      ],
       "has_key_file": true,
       "size": 32267,
       "modified": "2025-03-26T16:24:50",
@@ -1032,7 +980,6 @@
     "iz_test_images/Christina N. Piotrowski/IMG_0298.JPG": {
       "path": "iz_test_images/Christina N. Piotrowski/IMG_0298.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 24762,
       "modified": "2025-03-26T16:24:53",
@@ -1083,9 +1030,6 @@
     "iz_test_images/Christina N. Piotrowski/maldives specimen images/Maldives41562023_03_02.JPG": {
       "path": "iz_test_images/Christina N. Piotrowski/maldives specimen images/Maldives41562023_03_02.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        415620
-      ],
       "has_key_file": true,
       "size": 31906,
       "modified": "2025-03-26T16:24:50",
@@ -1139,9 +1083,6 @@
     "iz_test_images/Christina N. Piotrowski/maldives specimen images/mal- 0115  casiz 429836 perineris suluana/maldives00062023_03_06.jpg": {
       "path": "iz_test_images/Christina N. Piotrowski/maldives specimen images/mal- 0115  casiz 429836 perineris suluana/maldives00062023_03_06.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        620
-      ],
       "has_key_file": false,
       "size": 34683,
       "modified": "2025-03-26T16:24:51",
@@ -1165,7 +1106,6 @@
     "iz_test_images/Christina N. Piotrowski/DUP_Piotrowski_Hearst Exped_metadata includes CASIZ no/HEP specimens roll 1 30 apr 11 049.JPG": {
       "path": "iz_test_images/Christina N. Piotrowski/DUP_Piotrowski_Hearst Exped_metadata includes CASIZ no/HEP specimens roll 1 30 apr 11 049.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 27444,
       "modified": "2025-03-26T16:24:51",
@@ -1219,7 +1159,6 @@
     "iz_test_images/Christina N. Piotrowski/DUP_Piotrowski_Hearst Exped_metadata includes CASIZ no/2011-05-07 hep may 7 2011 roll_scope/hep may 7 2011 roll 006.jpg": {
       "path": "iz_test_images/Christina N. Piotrowski/DUP_Piotrowski_Hearst Exped_metadata includes CASIZ no/2011-05-07 hep may 7 2011 roll_scope/hep may 7 2011 roll 006.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": false,
       "size": 25644,
       "modified": "2025-03-26T16:24:52",
@@ -1239,7 +1178,6 @@
     "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2016/Piotrowski VIP 2016 SPECIMEN IMAGES/IMG_0832.JPG": {
       "path": "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2016/Piotrowski VIP 2016 SPECIMEN IMAGES/IMG_0832.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 27680,
       "modified": "2025-03-26T16:24:52",
@@ -1293,9 +1231,6 @@
     "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2016/Piotrowski VIP 2016 SPECIMEN IMAGES/casiz 219416_sia-04 juv diadema to rich/vip2016_04_06_201610_17_030600.jpg": {
       "path": "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2016/Piotrowski VIP 2016 SPECIMEN IMAGES/casiz 219416_sia-04 juv diadema to rich/vip2016_04_06_201610_17_030600.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        201610
-      ],
       "has_key_file": false,
       "size": 32012,
       "modified": "2025-03-26T16:24:53",
@@ -1319,9 +1254,6 @@
     "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2015/CASIZ 214715_VIP2015__2015_04_14_3666.JPG": {
       "path": "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2015/CASIZ 214715_VIP2015__2015_04_14_3666.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        214715
-      ],
       "has_key_file": true,
       "size": 35480,
       "modified": "2025-03-26T16:24:54",
@@ -1377,7 +1309,6 @@
     "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2015/cp vip 2015 specimen images batch 1 with metadata/casiz 214568 cp-0278 serpulidae eggs releasing/vip2015__2015_04_09_2240.jpg": {
       "path": "iz_test_images/Christina N. Piotrowski/Piotrowski VIP2015/cp vip 2015 specimen images batch 1 with metadata/casiz 214568 cp-0278 serpulidae eggs releasing/vip2015__2015_04_09_2240.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": false,
       "size": 39312,
       "modified": "2025-03-26T16:24:54",
@@ -1401,7 +1332,6 @@
     "iz_test_images/Sriram Ramamurthy/Image021_Overlay020.tif": {
       "path": "iz_test_images/Sriram Ramamurthy/Image021_Overlay020.tif",
       "extension": ".tif",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 35548,
       "modified": "2025-03-26T16:24:55",
@@ -1451,7 +1381,6 @@
     "iz_test_images/Jessica A. Goodheart Credit Jessica A. Goodheart © Jessica A. Goodheart/gill_plume_5x_32_B,Radius28,Smoothing1.tif": {
       "path": "iz_test_images/Jessica A. Goodheart Credit Jessica A. Goodheart © Jessica A. Goodheart/gill_plume_5x_32_B,Radius28,Smoothing1.tif",
       "extension": ".tif",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 35358,
       "modified": "2025-03-26T16:24:55.463312",
@@ -1501,7 +1430,6 @@
     "iz_test_images/Christopher L. Mah/IMG_5559.JPG": {
       "path": "iz_test_images/Christopher L. Mah/IMG_5559.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 26693,
       "modified": "2025-03-26T16:24:55",
@@ -1551,9 +1479,6 @@
     "iz_test_images/John L. Earle/CASIZ 097438 Goniobranchus_CAS photo slide scan.tif": {
       "path": "iz_test_images/John L. Earle/CASIZ 097438 Goniobranchus_CAS photo slide scan.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        97438
-      ],
       "has_key_file": true,
       "size": 26646,
       "modified": "2025-03-26T16:24:56",
@@ -1605,9 +1530,6 @@
     "iz_test_images/Mary K. Wicksten/CASIZ 185403_Epizoanthus giveni_Wicksten.JPG": {
       "path": "iz_test_images/Mary K. Wicksten/CASIZ 185403_Epizoanthus giveni_Wicksten.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        185403
-      ],
       "has_key_file": true,
       "size": 28297,
       "modified": "2025-03-26T16:24:56",
@@ -1659,9 +1581,6 @@
     "iz_test_images/Hanna Baek_primary types/CASIZ 116217 Ophiozona alba Syntype LABEL_1.JPG": {
       "path": "iz_test_images/Hanna Baek_primary types/CASIZ 116217 Ophiozona alba Syntype LABEL_1.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        116217
-      ],
       "has_key_file": true,
       "size": 30057,
       "modified": "2025-03-26T16:24:57",
@@ -1715,9 +1634,6 @@
     "iz_test_images/Henry Reiswig/CASIZ 184714 Hexanema root spicules_Reiswig.JPG": {
       "path": "iz_test_images/Henry Reiswig/CASIZ 184714 Hexanema root spicules_Reiswig.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        184714
-      ],
       "has_key_file": true,
       "size": 30109,
       "modified": "2025-03-26T16:24:57",
@@ -1770,9 +1686,6 @@
     "iz_test_images/Rosemary Golding/CASIZ 065116 Dendropoma krypta Paratypes_202_05 (1).tif": {
       "path": "iz_test_images/Rosemary Golding/CASIZ 065116 Dendropoma krypta Paratypes_202_05 (1).tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        65116
-      ],
       "has_key_file": true,
       "size": 31324,
       "modified": "2025-03-26T16:24:58",
@@ -1824,9 +1737,6 @@
     "iz_test_images/Joseph Comendador/CASIZ111359_20X_1.tif": {
       "path": "iz_test_images/Joseph Comendador/CASIZ111359_20X_1.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        111359
-      ],
       "has_key_file": true,
       "size": 31380,
       "modified": "2025-03-26T16:24:58",
@@ -1879,9 +1789,6 @@
     "iz_test_images/Daniel Killam UCSC/DSC03275.JPG": {
       "path": "iz_test_images/Daniel Killam UCSC/DSC03275.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        3275
-      ],
       "has_key_file": true,
       "size": 31648,
       "modified": "2025-03-26T16:24:58",
@@ -1932,9 +1839,6 @@
     "iz_test_images/Vanessa Guerra/CASIZ 185570 Myxicola_IMG_20110210_105637.jpg": {
       "path": "iz_test_images/Vanessa Guerra/CASIZ 185570 Myxicola_IMG_20110210_105637.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        185570
-      ],
       "has_key_file": true,
       "size": 56763,
       "modified": "2025-03-26T16:24:59",
@@ -1986,9 +1890,6 @@
     "iz_test_images/Gary C. Williams/CASIZ 185407_Tibiana tubes HEPD 026 scanWilliams.JPG": {
       "path": "iz_test_images/Gary C. Williams/CASIZ 185407_Tibiana tubes HEPD 026 scanWilliams.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        185407
-      ],
       "has_key_file": true,
       "size": 23462,
       "modified": "2025-03-26T16:24:59",
@@ -2041,9 +1942,6 @@
     "iz_test_images/John P. Hoover copyright John P. Hoover Photoslide Scans/CASIZ 105040 S2796 Ophiocoma pica © John P. Hoover.tif": {
       "path": "iz_test_images/John P. Hoover copyright John P. Hoover Photoslide Scans/CASIZ 105040 S2796 Ophiocoma pica © John P. Hoover.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        105040
-      ],
       "has_key_file": true,
       "size": 23389,
       "modified": "2025-03-26T16:25:00.079771",
@@ -2095,9 +1993,6 @@
     "iz_test_images/David Scheel/CASIZ 190941 Clade II RBR male 7126 c D Scheel.jpg": {
       "path": "iz_test_images/David Scheel/CASIZ 190941 Clade II RBR male 7126 c D Scheel.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        190941
-      ],
       "has_key_file": true,
       "size": 24404,
       "modified": "2025-03-26T16:25:00",
@@ -2149,9 +2044,6 @@
     "iz_test_images/Ralph Olen Fox/CASIZ 192393 Clade II RGR IMG_9529 c R Fox.jpg": {
       "path": "iz_test_images/Ralph Olen Fox/CASIZ 192393 Clade II RGR IMG_9529 c R Fox.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        192393
-      ],
       "has_key_file": true,
       "size": 31237,
       "modified": "2025-03-26T16:25:01",
@@ -2203,7 +2095,6 @@
     "iz_test_images/Sergio Salazar-Vallejo/IMG_9719.JPG": {
       "path": "iz_test_images/Sergio Salazar-Vallejo/IMG_9719.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 22703,
       "modified": "2025-03-26T16:25:01",
@@ -2256,7 +2147,6 @@
     "iz_test_images/Sheila Nadimi/BW_03_Pisidium milium.tif": {
       "path": "iz_test_images/Sheila Nadimi/BW_03_Pisidium milium.tif",
       "extension": ".tif",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 23159,
       "modified": "2025-03-26T16:25:01",
@@ -2306,9 +2196,6 @@
     "iz_test_images/Monterey Bay Aquarium Research Institute/CASIZ 190478 AND 190479 Bathydorus laniger paratypes T1142 PULSE 53__15_15_39_05.JPG": {
       "path": "iz_test_images/Monterey Bay Aquarium Research Institute/CASIZ 190478 AND 190479 Bathydorus laniger paratypes T1142 PULSE 53__15_15_39_05.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        190478
-      ],
       "has_key_file": true,
       "size": 23027,
       "modified": "2025-03-26T16:25:02",
@@ -2363,9 +2250,6 @@
     "iz_test_images/Mikihito Arai/P3210001.JPG": {
       "path": "iz_test_images/Mikihito Arai/P3210001.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        321000
-      ],
       "has_key_file": true,
       "size": 41313,
       "modified": "2025-03-26T16:25:03",
@@ -2417,9 +2301,6 @@
     "iz_test_images/Victor Smith copyright CAS/CASIZ171855_D.JPG": {
       "path": "iz_test_images/Victor Smith copyright CAS/CASIZ171855_D.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        171855
-      ],
       "has_key_file": true,
       "size": 41327,
       "modified": "2025-03-26T16:25:03",
@@ -2473,9 +2354,6 @@
     "iz_test_images/Robert Ames copyright Unknown Photoslide Scans/CASIZ 005833 S1373 Stylaster Robert Ames Photo Unknown Copyright.tif": {
       "path": "iz_test_images/Robert Ames copyright Unknown Photoslide Scans/CASIZ 005833 S1373 Stylaster Robert Ames Photo Unknown Copyright.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        5833
-      ],
       "has_key_file": true,
       "size": 40178,
       "modified": "2025-03-26T16:25:03",
@@ -2527,9 +2405,6 @@
     "iz_test_images/Terrence M. Gosliner_Photo slides/CASIZ 081334 S2912 Echinodiscus tenuissimus © T.M. Gosliner.tif": {
       "path": "iz_test_images/Terrence M. Gosliner_Photo slides/CASIZ 081334 S2912 Echinodiscus tenuissimus © T.M. Gosliner.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        81334
-      ],
       "has_key_file": true,
       "size": 40245,
       "modified": "2025-03-26T16:25:04.231009",
@@ -2582,9 +2457,6 @@
     "iz_test_images/Rikke K.F. Jeppesen/CASIZ 22878 Malacoplax_californiensis_01.JPG": {
       "path": "iz_test_images/Rikke K.F. Jeppesen/CASIZ 22878 Malacoplax_californiensis_01.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        22878
-      ],
       "has_key_file": true,
       "size": 29710,
       "modified": "2025-03-26T16:25:04",
@@ -2636,9 +2508,6 @@
     "iz_test_images/Kelly Markello Copyright CAS/CASIZ065098_Trophon(Acanthotrophon)_sorenseni_holotype.tif": {
       "path": "iz_test_images/Kelly Markello Copyright CAS/CASIZ065098_Trophon(Acanthotrophon)_sorenseni_holotype.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        65098
-      ],
       "has_key_file": true,
       "size": 31241,
       "modified": "2025-03-26T16:25:05",
@@ -2691,7 +2560,6 @@
     "iz_test_images/Nancy Treneman/DSCN0759.JPG": {
       "path": "iz_test_images/Nancy Treneman/DSCN0759.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 40469,
       "modified": "2025-03-26T16:25:05",
@@ -2741,9 +2609,6 @@
     "iz_test_images/Michael P. Montgomery/CASIZ 118986_Photo 1.JPG": {
       "path": "iz_test_images/Michael P. Montgomery/CASIZ 118986_Photo 1.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        118986
-      ],
       "has_key_file": true,
       "size": 40383,
       "modified": "2025-03-26T16:25:05",
@@ -2795,9 +2660,6 @@
     "iz_test_images/Beth Moore/CASIZ185402 Sep11 photo B AmphinomidaeBM010.JPG": {
       "path": "iz_test_images/Beth Moore/CASIZ185402 Sep11 photo B AmphinomidaeBM010.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        185402
-      ],
       "has_key_file": true,
       "size": 41678,
       "modified": "2025-03-26T16:25:06",
@@ -2850,9 +2712,6 @@
     "iz_test_images/Karin Fletcher Credit Karin Fletcher © Karin Fletcher/CASIZ 185202 O. muricata measurement.jpg": {
       "path": "iz_test_images/Karin Fletcher Credit Karin Fletcher © Karin Fletcher/CASIZ 185202 O. muricata measurement.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        185202
-      ],
       "has_key_file": true,
       "size": 35541,
       "modified": "2025-03-26T16:25:06.807990",
@@ -2904,9 +2763,6 @@
     "iz_test_images/James McLean/baetica CAS 064353 holotype of diegensis Credit James McLean.tif": {
       "path": "iz_test_images/James McLean/baetica CAS 064353 holotype of diegensis Credit James McLean.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        64353
-      ],
       "has_key_file": true,
       "size": 35687,
       "modified": "2025-03-26T16:25:07",
@@ -2958,9 +2814,6 @@
     "iz_test_images/Anne K. DuPont copyright CAS/CASIZ 241666 Lamellaria # 1 dorsal LWL DSC_00882  4-16-2013.jpg": {
       "path": "iz_test_images/Anne K. DuPont copyright CAS/CASIZ 241666 Lamellaria # 1 dorsal LWL DSC_00882  4-16-2013.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        241666
-      ],
       "has_key_file": true,
       "size": 36650,
       "modified": "2025-03-26T16:25:07",
@@ -3012,9 +2865,6 @@
     "iz_test_images/National Oceanic and Atmospheric Administration/cam1_20160824162505_CASIZ 218811.png": {
       "path": "iz_test_images/National Oceanic and Atmospheric Administration/cam1_20160824162505_CASIZ 218811.png",
       "extension": ".png",
-      "casiz_numbers": [
-        218811
-      ],
       "has_key_file": true,
       "size": 36378,
       "modified": "2025-03-26T16:25:08",
@@ -3066,9 +2916,6 @@
     "iz_test_images/Antonio J. Ferreira_Photo slides/CASIZ 15602 Lepidopleurus scrippsianus Holotype  A.J. Ferreira Image 26.TIF": {
       "path": "iz_test_images/Antonio J. Ferreira_Photo slides/CASIZ 15602 Lepidopleurus scrippsianus Holotype  A.J. Ferreira Image 26.TIF",
       "extension": ".tif",
-      "casiz_numbers": [
-        15602
-      ],
       "has_key_file": true,
       "size": 36370,
       "modified": "2025-03-26T16:25:08",
@@ -3121,9 +2968,6 @@
     "iz_test_images/Thomas Turner/CASIZ 235106.jpg": {
       "path": "iz_test_images/Thomas Turner/CASIZ 235106.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        235106
-      ],
       "has_key_file": true,
       "size": 36436,
       "modified": "2025-03-26T16:25:08",
@@ -3175,9 +3019,6 @@
     "iz_test_images/Christina Piotrowski Copyright CAS/CASIZ 016426 Callistochiton portobelensis Holotype_3.tif": {
       "path": "iz_test_images/Christina Piotrowski Copyright CAS/CASIZ 016426 Callistochiton portobelensis Holotype_3.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        16426
-      ],
       "has_key_file": true,
       "size": 33076,
       "modified": "2025-03-26T16:25:10",
@@ -3230,9 +3071,6 @@
     "iz_test_images/Christina Piotrowski Copyright CAS/CASIZ 060803 Stagnicola hemphilli HOLOTYPE/CASIZ 060803 Stagnicola hemphilli HOLOTYPE dorsal1.tif": {
       "path": "iz_test_images/Christina Piotrowski Copyright CAS/CASIZ 060803 Stagnicola hemphilli HOLOTYPE/CASIZ 060803 Stagnicola hemphilli HOLOTYPE dorsal1.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        60803
-      ],
       "has_key_file": true,
       "size": 36733,
       "modified": "2025-03-26T16:25:09",
@@ -3290,7 +3128,6 @@
     "iz_test_images/Christina Piotrowski Copyright CAS/paratype CASIZ 60451/CAS type shells 014.jpg": {
       "path": "iz_test_images/Christina Piotrowski Copyright CAS/paratype CASIZ 60451/CAS type shells 014.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 32944,
       "modified": "2025-03-26T16:25:09",
@@ -3346,7 +3183,6 @@
     "iz_test_images/Christina Piotrowski Copyright CAS/CASIZ 063814 Erronia stohleri HOLOTYPE/CASIZ 63814_SLR/Holotype CASIZ_63814/photos SLR 2-9-09/CAS type shells 002.jpg": {
       "path": "iz_test_images/Christina Piotrowski Copyright CAS/CASIZ 063814 Erronia stohleri HOLOTYPE/CASIZ 63814_SLR/Holotype CASIZ_63814/photos SLR 2-9-09/CAS type shells 002.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 30985,
       "modified": "2025-03-26T16:25:10",
@@ -3402,9 +3238,6 @@
     "iz_test_images/Alejandra Hernandez/CASIZ 242868_H194_p1.png": {
       "path": "iz_test_images/Alejandra Hernandez/CASIZ 242868_H194_p1.png",
       "extension": ".png",
-      "casiz_numbers": [
-        242868
-      ],
       "has_key_file": true,
       "size": 30871,
       "modified": "2025-03-26T16:25:11",
@@ -3456,9 +3289,6 @@
     "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 016317 Dendronotus diversicolor Holotype EJ Kools © California Academy of Sciences IMG_1656.JPG": {
       "path": "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 016317 Dendronotus diversicolor Holotype EJ Kools © California Academy of Sciences IMG_1656.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        16317
-      ],
       "has_key_file": true,
       "size": 43728,
       "modified": "2025-03-26T16:25:11.576485",
@@ -3511,9 +3341,6 @@
     "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064663 Cypraea (Erosaria) cernica viridicolor Holotype EJ Kools/CASIZ 064663 Cypraea (Erosaria) cernica viridicolor IMG_1444 (10).JPG": {
       "path": "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064663 Cypraea (Erosaria) cernica viridicolor Holotype EJ Kools/CASIZ 064663 Cypraea (Erosaria) cernica viridicolor IMG_1444 (10).JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        64663
-      ],
       "has_key_file": true,
       "size": 34691,
       "modified": "2025-03-26T16:25:12",
@@ -3571,9 +3398,6 @@
     "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064663 Cypraea (Erosaria) cernica viridicolor Holotype EJ Kools/For Ulf Erdmann/CASIZ 064663 Cypraea (Erosaria) cernica viridicolor IMG_1444 (10).JPG": {
       "path": "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064663 Cypraea (Erosaria) cernica viridicolor Holotype EJ Kools/For Ulf Erdmann/CASIZ 064663 Cypraea (Erosaria) cernica viridicolor IMG_1444 (10).JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        64663
-      ],
       "has_key_file": true,
       "size": 34691,
       "modified": "2025-03-26T16:25:12",
@@ -3631,9 +3455,6 @@
     "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064302 Pleurobranchus californicus Syntype Credit EJ Kools © California Academy of Sciences/CASIZ 064302 LABEL.jpg": {
       "path": "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064302 Pleurobranchus californicus Syntype Credit EJ Kools © California Academy of Sciences/CASIZ 064302 LABEL.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        64302
-      ],
       "has_key_file": true,
       "size": 44472,
       "modified": "2025-03-26T16:25:13.422127",
@@ -3691,9 +3512,6 @@
     "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064302 Pleurobranchus californicus Syntype Credit EJ Kools © California Academy of Sciences/To Angel/CASIZ 064302 Pleurobranchus californicus Syntype10.tif": {
       "path": "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064302 Pleurobranchus californicus Syntype Credit EJ Kools © California Academy of Sciences/To Angel/CASIZ 064302 Pleurobranchus californicus Syntype10.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        64302
-      ],
       "has_key_file": true,
       "size": 34648,
       "modified": "2025-03-26T16:25:13.004955",
@@ -3751,9 +3569,6 @@
     "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064334 Pecten velero biolleyi Holotype/CASIZ 064334 Pecten velero biolleyi Holotype R valve ext1 EJ Kools © California Academy of Sciences.tif": {
       "path": "iz_test_images/Elizabeth Kools Copyright CAS/CASIZ 064334 Pecten velero biolleyi Holotype/CASIZ 064334 Pecten velero biolleyi Holotype R valve ext1 EJ Kools © California Academy of Sciences.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        64334
-      ],
       "has_key_file": true,
       "size": 44716,
       "modified": "2025-03-26T16:25:13.736503",
@@ -3811,7 +3626,6 @@
     "iz_test_images/Ibrahim Jilwaz/IMG_0236.jpeg": {
       "path": "iz_test_images/Ibrahim Jilwaz/IMG_0236.jpeg",
       "extension": ".jpeg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 44448,
       "modified": "2025-03-26T16:25:14",
@@ -3862,9 +3676,6 @@
     "iz_test_images/Sioban O'Neill Credit Siobhan O'Neill © Sioban O'Neill/CASIZ 241488 Aeolid Sp Siobhan ONeill IMG_7745.jpeg": {
       "path": "iz_test_images/Sioban O'Neill Credit Siobhan O'Neill © Sioban O'Neill/CASIZ 241488 Aeolid Sp Siobhan ONeill IMG_7745.jpeg",
       "extension": ".jpeg",
-      "casiz_numbers": [
-        241488
-      ],
       "has_key_file": true,
       "size": 43918,
       "modified": "2025-03-26T16:25:14.523216",
@@ -3916,9 +3727,6 @@
     "iz_test_images/Robert Van Syoc_Photo slides/CASIZ 060145 Cassiopea S583 © Robert Van Syoc.tif": {
       "path": "iz_test_images/Robert Van Syoc_Photo slides/CASIZ 060145 Cassiopea S583 © Robert Van Syoc.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        60145
-      ],
       "has_key_file": true,
       "size": 43972,
       "modified": "2025-03-26T16:25:14.902416",
@@ -3971,7 +3779,6 @@
     "iz_test_images/Catherine S. McFadden/DSCN8448.JPG": {
       "path": "iz_test_images/Catherine S. McFadden/DSCN8448.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 28798,
       "modified": "2025-03-26T16:25:15",
@@ -4021,9 +3828,6 @@
     "iz_test_images/Vanessa L. Knutson © Vanessa L. Knutson/Gymnodoris_sp._white_PR229_PCA693_CASIZ190792_0854.JPG": {
       "path": "iz_test_images/Vanessa L. Knutson © Vanessa L. Knutson/Gymnodoris_sp._white_PR229_PCA693_CASIZ190792_0854.JPG",
       "extension": ".jpg",
-      "casiz_numbers": [
-        190792
-      ],
       "has_key_file": true,
       "size": 28971,
       "modified": "2025-03-26T16:25:15.843514",
@@ -4079,9 +3883,6 @@
     "iz_test_images/Rich Mooi/CASIZ 186310 Caymanostellid composite.jpg": {
       "path": "iz_test_images/Rich Mooi/CASIZ 186310 Caymanostellid composite.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        186310
-      ],
       "has_key_file": true,
       "size": 30660,
       "modified": "2025-03-26T16:25:16",
@@ -4134,9 +3935,6 @@
     "iz_test_images/Robin Gwen Agarwal/CASIZ 234658 Tenellia adspersa P3301433 San Diego Robin Agarwal PS.jpg": {
       "path": "iz_test_images/Robin Gwen Agarwal/CASIZ 234658 Tenellia adspersa P3301433 San Diego Robin Agarwal PS.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        234658
-      ],
       "has_key_file": true,
       "size": 32118,
       "modified": "2025-03-26T16:25:16",
@@ -4188,9 +3986,6 @@
     "iz_test_images/Elena Oey Credit Elena Oey © Elena Oey/CASIZ 241488 Aeolid Sp Elena Oey PC160218.jpg": {
       "path": "iz_test_images/Elena Oey Credit Elena Oey © Elena Oey/CASIZ 241488 Aeolid Sp Elena Oey PC160218.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        241488
-      ],
       "has_key_file": true,
       "size": 93923,
       "modified": "2025-03-26T16:25:17.324508",
@@ -4242,9 +4037,6 @@
     "iz_test_images/Credit Unknown copyright Unknown Photoslide Scans/CASIZ 035073 S898 Heteractis magnifica Credit Unknown.tif": {
       "path": "iz_test_images/Credit Unknown copyright Unknown Photoslide Scans/CASIZ 035073 S898 Heteractis magnifica Credit Unknown.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        35073
-      ],
       "has_key_file": true,
       "size": 93251,
       "modified": "2025-03-26T16:25:17",
@@ -4296,9 +4088,6 @@
     "iz_test_images/Terrence M. Gosliner/CASIZ 024961 Turbonilla evermanni holotype a.tif": {
       "path": "iz_test_images/Terrence M. Gosliner/CASIZ 024961 Turbonilla evermanni holotype a.tif",
       "extension": ".tif",
-      "casiz_numbers": [
-        24961
-      ],
       "has_key_file": true,
       "size": 93448,
       "modified": "2025-03-26T16:25:18",
@@ -4351,7 +4140,6 @@
     "iz_test_images/Meghan Yap Chiongco/Photo on 12-19-18 at 1.29 PM #2.jpg": {
       "path": "iz_test_images/Meghan Yap Chiongco/Photo on 12-19-18 at 1.29 PM #2.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [],
       "has_key_file": true,
       "size": 93270,
       "modified": "2025-03-26T16:25:18",
@@ -4401,9 +4189,6 @@
     "iz_test_images/Johanna Loacker/CASIZ 234193.jpg": {
       "path": "iz_test_images/Johanna Loacker/CASIZ 234193.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        234193
-      ],
       "has_key_file": true,
       "size": 93488,
       "modified": "2025-03-26T16:25:19",
@@ -4455,9 +4240,6 @@
     "iz_test_images/Specimen labels/CASIZ 064302 LABEL.jpg": {
       "path": "iz_test_images/Specimen labels/CASIZ 064302 LABEL.jpg",
       "extension": ".jpg",
-      "casiz_numbers": [
-        64302
-      ],
       "has_key_file": true,
       "size": 100315,
       "modified": "2025-03-26T16:25:19",

--- a/tests/iz_importer_tests/test_casiz.py
+++ b/tests/iz_importer_tests/test_casiz.py
@@ -6,7 +6,6 @@ IzImporter.__init__
 │       ├── get_casiz_ids
 │       │   ├── attempt_filename_match
 │       │   │   └── extract_casiz_from_string
-│       │   │       ├── extract_exact_casiz_match
 │       │   │       └── extract_casiz_single
 │       │   ├── get_casiz_from_exif
 │       │   │   └── extract_casiz_from_string
@@ -31,116 +30,6 @@ class TestIzImporterCasiz(TestIzImporterBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def test_extract_casiz_single(self, mock_specify_db):
-        self._getImporter(mock_specify_db)
-        
-        # Valid cases - numbers with 5-10 digits
-        test_cases = [
-            ("12345", 12345),               # Minimum digits (5)
-            ("123456", 123456),             # 6 digits
-            ("123456789", 123456789),       # 9 digits
-            ("12345 and 66772", 12345),     # two numbers in string
-            ("1234567890", 1234567890),     # Maximum digits (10)
-            ("123456789012", 1234567890),   # more than 10 digits
-            ("12345678901_CASIZ.jpg", 1234567890),  # more than 10 digits in filename
-            ("CASIZ 12345", 12345),         # With CASIZ prefix
-            ("abc123456def", 123456),       # Number embedded in text
-            ("12345.jpg", 12345),           # Number in filename
-            ("1234abc1234565", 1234565),    # Number with letters in middle
-            ("path/to/123456.jpg", 123456), # Number in path
-            ("IMG_1234567_CASIZ.jpg", 1234567), # Complex filename
-            ("test-12345", 12345),          # Number with dash
-            ("©12345", 12345),              #latin-1 encoding
-        ]
-        
-        for input_str, expected in test_cases:
-            self.assertEqual(
-                self.importer.extract_casiz_single(input_str), 
-                expected,
-                f"Failed to extract {expected} from '{input_str}'"
-            )
-        
-        # Invalid cases
-        invalid_cases = [
-            "1234",          # Too few digits (< 5)
-            "abcdef",        # No numbers
-            "",              # Empty string
-            "12.34",         # Decimal number
-            "123-456",       # Hyphenated number
-            "1234a6789",    # Number interrupted by letter
-            "12.345.678",    # Numbers separated by dots
-        ]
-        
-        for input_str in invalid_cases:
-            self.assertIsNone(
-                self.importer.extract_casiz_single(input_str),
-                f"Should return None for invalid input '{input_str}'"
-            )
-
-    def test_extract_exact_casiz_match(self, mock_specify_db):
-        self._getImporter(mock_specify_db)
-        # test cases for CASIZ_NUMBER_EXACT
-        CASIZ_NUMBER_EXACT_test_cases = [
-            # Valid matches
-            ("casiz12345", "12345"),
-            ("casiz_sample_67890", "67890"),
-            ("test casiz_image-54321", "54321"),
-            ("casiz_image-543", "543"),
-            ("image casiz_54321", "54321"),
-
-            ("abc_casiz_label# 88888", "88888"),
-            ("casiz path test 99999", "99999"),
-
-            # Mixed case prefix
-            ("CaSiZ_image_12345", "12345"),
-
-            # 'casiz' present but no digits
-            ("casiz-only", None),
-            ("casiz_image", None),
-
-            ("casiz path\\_99999", None),
-
-            ("casiz/image_dir_00001", None),
-            ("casiz©-77777", None),
-            # Edge: Multiple digits in string, ensure it picks only the one after CAS
-            ("image123 casiz_something-44444 file999", "44444"),
-        ]
-
-        # test cases for CASIZ_MATCH
-        CASIZ_MATCH_test_cases = [
-            ("cas 123", "cas 123"),
-            ("casiz test 123", "casiz test 123"),
-            ("cas_abc_123456def", "cas_abc_123456"),
-            ("cas_abc_1234def", "cas_abc_1234"),
-            ("cas_x-1234def", "cas_x-1234"),
-            ("cas1234", "cas1234"),
-            ("ca 125", None),
-            ("cas 1", None),
-            ("12", None),
-            ("cas 123456789012test", "cas 1234567890"),
-            ("image123 _something-4444 file999", None),
-
-        ]
-        
-        for input_str, expected in CASIZ_NUMBER_EXACT_test_cases:
-            result = self.importer.extract_exact_casiz_match(input_str)
-            if expected is None:
-                self.assertIsNone(result, f"Expected None for input '{input_str}', but got {result}")
-            else:
-                self.assertIsNotNone(result, f"Expected match for input '{input_str}', but got None")
-                self.assertEqual(
-                    result.group(2),
-                    expected,
-                    f"Failed to extract {expected} from '{input_str}'"
-                )
-        for input_str, expected in CASIZ_MATCH_test_cases:
-            result = self.importer.extract_exact_casiz_match(input_str)
-            if expected is None:
-                self.assertIsNone(result, f"Expected None for input '{input_str}', but got {result}")
-            else:
-                self.assertIsNotNone(result, f"Expected match for input '{input_str}', but got None")
-                self.assertEqual(result.group(0), expected, f"Failed to extract {expected} from '{input_str}'")
-
     def test_extract_casiz_from_string(self, mock_specify_db):
         self._getImporter(mock_specify_db)
         
@@ -151,17 +40,19 @@ class TestIzImporterCasiz(TestIzImporterBase):
             ("casiz_123456 VS 2233", [123456]),
             ("1234234", [1234234]),
             ("1234567890", [1234567890]),
-            ("123456789012", [1234567890]),
-            ("12345678901_CASIZ.jpg", [1234567890]),
+            ("123456789012", [123456789012]),
+            ("12345678901_CASIZ.jpg", [12345678901]),
+            ("casiz123456def", [123456]),
             ("CASIZ 12345", [12345]),
-            ("abc123456def", [123456]),
             ("12345.jpg", [12345]),
-            ("1234abc1234565", [1234565]),
+            ("1234cas1234565", [1234565]),
             ("some/random_file", None),
             ("archive/casiz-123456 and 78901 and cas#654321.png", [123456, 78901, 654321]),
             ("12345 and 12345", [12345]),
-            ("cas_x-1234def", [1234]),
             ("cas1234", [1234]),
+            ("cas_x-1234def", None),
+            ("1234abc1234565", None),
+            ("abc123456def", None),
             ("ca 125", None),
             ("cas 1", None),
             ("12", None)
@@ -238,6 +129,8 @@ class TestIzImporterCasiz(TestIzImporterBase):
         test_file_dir = os.path.dirname(__file__)
         mock_data = self.get_mock_data()
         for file_path, file_info in mock_data['files'].items():
+            if file_info.get('skip_test'):
+                continue
             full_path = os.path.join(test_file_dir, file_path)
             exif_metadata = self.importer._read_exif_metadata(full_path)
             casiz_from = self.importer.get_casiz_ids(file_path, exif_metadata)

--- a/tests/iz_importer_tests/test_casiz.py
+++ b/tests/iz_importer_tests/test_casiz.py
@@ -80,7 +80,6 @@ class TestIzImporterCasiz(TestIzImporterBase):
             result = self.importer.attempt_filename_match(os.path.basename(file_path))
             if file_info['casiz']['from_filename'] is not None:
                 self.assertTrue(result, f"Expected match {file_info['casiz']['from_filename']} for {file_path}")
-                #breakpoint()
                 self.assertEqual(self.importer.casiz_numbers, file_info['casiz']['from_filename'], \
                                  f"Expected {file_info['casiz']['from_filename']} for {file_path}")
             else:

--- a/tests/iz_importer_tests/test_casiz.py
+++ b/tests/iz_importer_tests/test_casiz.py
@@ -189,6 +189,7 @@ class TestIzImporterCasiz(TestIzImporterBase):
             result = self.importer.attempt_filename_match(os.path.basename(file_path))
             if file_info['casiz']['from_filename'] is not None:
                 self.assertTrue(result, f"Expected match {file_info['casiz']['from_filename']} for {file_path}")
+                #breakpoint()
                 self.assertEqual(self.importer.casiz_numbers, file_info['casiz']['from_filename'], \
                                  f"Expected {file_info['casiz']['from_filename']} for {file_path}")
             else:


### PR DESCRIPTION
rewrite the logic to parse CASIZ number from filename, directory and exif metadata:
adding new rules:


1. avoid matching IZACC number 
2. avoid camera serial number such as DSCXXXX (nikon) or PXXXX(Olympas)
3. avoid date like numbers (such as 20240223) if no CASIZ prefix presented
4. if numbers are AND/OR keyword and only those keyword are connected, take them all
5. if CASIZ prefix not present, assume the number(s) as valid CASIZ unless the above condition applies
6. matching order follows filename -> directory -> metadata