### PR TITLE
Fix EXIF clearing logic and add unit test

### DIFF
--- a/config_files/iz_config.template.py
+++ b/config_files/iz_config.template.py
@@ -10,6 +10,7 @@ PASSWORD = '123pass'
 
 REPORT_PATH = f"html_reports{sla}iz_import_monitoring.html"
 COLLECTION_NAME = "IZ"
+CLEAR_EXIF_FIELDS = ["XMP:Title", "IPTC:Caption-Abstract", "EXIF:ImageDescription"]
 
 AGENT_ID = 123456
 

--- a/config_files/iz_config.template.py
+++ b/config_files/iz_config.template.py
@@ -24,9 +24,7 @@ IZ_SCAN_FOLDERS = [
     f'/Volumes/images/izg/iz',  # core images - pegasus
     f'/Volumes/data/izg/IZ Images/CASIZ Label Images' # label data
 ]
-# IZ_SCAN_FOLDERS = [
-#     f'/Users/joe/web-asset-importer/test_images'
-# ]
+
 
 
 

--- a/iz_import.md
+++ b/iz_import.md
@@ -1,0 +1,49 @@
+# `key.csv` End‑User Reference
+
+`key.csv` lets you control how each image is imported without touching code.  Place the file in the same folder as your images (or any parent folder); the importer walks **upwards** until it finds the first `key.csv`.
+
+* Two‑column CSV: **key**, **value**
+* Keys are case‑insensitive; blank values are ignored.
+* Unknown keys are ignored.
+
+---
+
+## Supported Keys
+
+| Key (column 0)                     | Expected Value                                                     | What It Does                                                                                                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CopyrightDate`                    | Date in **`YYYY‑MM‑DD`**, **`MM/DD/YYYY`**, or **`Month D, YYYY`** | Sets the year shown in Specify’s *Copyright Date* field. If omitted the importer falls back to the imageʼs EXIF CreateDate.                                                      |
+| `CopyrightHolder`                  | Text                                                               | Sets the *Copyright Holder* for EXIF embedding and for Specify.                                                                                                                  |
+| `Credit`                           | Text                                                               | Written to the EXIF/IPTC *Credit* tag and to Specifyʼs *Credit* field.                                                                                                           |
+| `License`                          | Text                                                               | Saved to Specifyʼs *License* field and XMP Usage tags.                                                                                                                           |
+| `Remarks`                          | Text                                                               | Copied into Specifyʼs *Remarks*.                                                                                                                                                 |
+| `IsPublic`                         | `true` / `false`                                                   | `true` → image is *public* (no redaction); `false` → image is flagged *not public* and attachment is created with redaction enforced.                                            |
+| `subType`                          | Text                                                               | Fills Specifyʼs *Subtype* (e.g. `dorsal`, `ventral`).                                                                                                                            |
+| `createdByAgent`                   | Agent name                                                         | Looked up (fuzzy match) in Specify and linked as *Created By*.  Overrides the default `AGENT_ID`.                                                                                |
+| `creator` *(alias `MetaDataText`)* | Text                                                               | Goes into EXIF *Artist* / IPTC *By‑line* and Specifyʼs *Metadata Text*.  Also used for agent lookup when `createdByAgent` is absent.                                             |
+| `remove`                           | `true` / `false`                                                   | When **`true`** the file is **deleted** from the image DB and detached from Specify if already present; the importer logs the action and skips further processing for that file. |
+| `erase_exif_fields`                | `true` / `false`                                                   | When **`true`** the importer **blanks** the following tags before continuing:<br>• `XMP:Title`<br>• `IPTC:Caption‑Abstract`<br>• `EXIF:ImageDescription`                         |
+
+---
+
+### Minimal Example
+
+```csv
+CopyrightHolder,California Academy of Sciences
+IsPublic,false
+subType,dorsal
+creator,Jane Doe
+```
+
+### Full Example (demonstrating `remove` & `erase_exif_fields`)
+
+```csv
+remove,true
+erase_exif_fields,true
+```
+
+Above file would cause every image in the directory to be removed from the database **and** have the specified EXIF fields cleared.
+
+---
+
+**Tip:** Keep one `key.csv` per logical batch.  Place it at the highest level whose settings you want to inherit; subfolders without their own `key.csv` will use the nearest one up the tree.

--- a/iz_importer.py
+++ b/iz_importer.py
@@ -392,6 +392,10 @@ class IzImporter(Importer):
             self.remove_file_from_database(full_path)
             return FILENAME_BUILD_STATUS.REMOVED_FILE, False
 
+        if file_key and str(file_key.get('erase_exif_fields', '')).lower() == 'true':
+            self.logger.info(f"Clearing exif fields in: {full_path} and continuing...")
+            self._clear_exif_fields(full_path)
+
         if self._is_file_already_processed(full_path, orig_case_full_path):
             return FILENAME_BUILD_STATUS.ALREADY_PROCESSED, False
 
@@ -414,6 +418,43 @@ class IzImporter(Importer):
                              copyright=self.copyright)
         return FILENAME_BUILD_STATUS.SUCCESS, True
 
+    # ---------------------------------------------------------------------------
+    # _clear_exif_fields
+    #
+    # Purpose:
+    #     Blank the metadata values configured in iz_config.CLEAR_EXIF_FIELDS
+    #     (rather than hard‑coding them in the method) to remove sensitive or
+    #     user‑visible information from an image.
+    #
+    # Steps:
+    #     1. Instantiate MetadataTools for the supplied path.
+    #     2. Read existing EXIF/IPTC/XMP tags.
+    #     3. For each configured tag, log its current value for debugging.
+    #     4. Set each configured tag to None (blank) in the tag dictionary.
+    #     5. Write the updated tags back to the file, forcing blank overwrite.
+    #
+    # Args:
+    #     full_path (str): Absolute path to the image whose metadata is cleared.
+    #
+    # Returns:
+    #     None
+    # ---------------------------------------------------------------------------
+    def _clear_exif_fields(self, full_path):
+        self.logger.debug(f"Clearing EXIF fields in: {full_path}")
+        target_fields = self.iz_importer_config.CLEAR_EXIF_FIELDS
+
+        exif_tools = MetadataTools(full_path)
+        if not exif_tools:
+            return
+
+
+        if self.logger.isEnabledFor(logging.DEBUG):
+            current = exif_tools.read_exif_tags()
+            for f in target_fields:
+                self.logger.debug(f"Old value for {f}: {current.get(f)}")
+
+        blank_tags = {field: None for field in target_fields}
+        exif_tools.write_exif_tags(blank_tags, overwrite_blank=True)
 
     def _check_and_increment_counter(self):
         if 'counter' not in globals():
@@ -617,8 +658,8 @@ class IzImporter(Importer):
             'subtype': 'subType',
             'createdbyagent': 'createdByAgent',
             'metadatatext': 'creator',
-            'remove': 'remove'
-
+            'remove': 'remove',
+            'erase_exif_fields':'erase_exif_fields'
         }
 
         result_dict = {mapped_key: None for mapped_key in column_mappings.values()}


### PR DESCRIPTION
### Summary
* Move CLEAR_EXIF_FIELDS to config
* _clear_exif_fields now writes only the blank tags
* New temp‑file test to verify clearing without mutating fixtures

Closes #110