### PR TITLE
small fix to get image magick conver to read temp files in both mac os and ubuntu

### DIFF
--- a/botany_importer.py
+++ b/botany_importer.py
@@ -40,7 +40,6 @@ class BotanyImporter(Importer):
 
         for cur_dir in self.paths:
             self.dir_tools.process_files_or_directories_recursive(cur_dir)
-
         self.process_loaded_files()
 
         if not self.full_import and self.botany_importer_config.MAILING_LIST:
@@ -50,9 +49,6 @@ class BotanyImporter(Importer):
                                                                       time_stamp=starting_time_stamp,
                                                                       image_dict=image_dict)
 
-
-        # FILENAME = "bio_importer.bin"
-        # if not os.path.exists(FILENAME):
 
 
     def process_loaded_files(self):
@@ -80,9 +76,11 @@ class BotanyImporter(Importer):
         #  we can have multiple filepaths per barcode in the case of barcode-a, barcode-b etc.
         # not done for modern samples, but historically this exists.
         # when removed the unittest
+
         filepath_list = self.clean_duplicate_basenames(filepath_list)
         filepath_list = self.clean_duplicate_image_barcodes(filepath_list)
         filepath_list = self.remove_imagedb_imported_filenames_from_list(filepath_list)
+
 
         if self.full_import and not self.existing_barcodes:
             agent_id = self.botany_importer_config.IMPORTER_AGENT_ID

--- a/importer.py
+++ b/importer.py
@@ -45,9 +45,7 @@ class Importer:
         self.image_client = ImageClient(config=db_config_class)
         self.attachment_utils = AttachmentUtils(self.specify_db_connection)
         self.duplicates_file = open(f'duplicates-{self.collection_name}.txt', 'w')
-        self.TMP_JPG = f"./tmp_jpg_{self.image_client.generate_token(filename=str(uuid4()))}"
-        # for compatibility between ubuntu/debian/unix command line
-        self.TMP_JPG = self.TMP_JPG.replace(":", "_")
+        self.TMP_JPG = f"./tmp_jpg_{str(uuid4())}"
         self.execute_at_exit()
 
     def split_filepath(self, filepath):

--- a/importer.py
+++ b/importer.py
@@ -46,6 +46,8 @@ class Importer:
         self.attachment_utils = AttachmentUtils(self.specify_db_connection)
         self.duplicates_file = open(f'duplicates-{self.collection_name}.txt', 'w')
         self.TMP_JPG = f"./tmp_jpg_{self.image_client.generate_token(filename=str(uuid4()))}"
+        # for compatibility between ubuntu/debian/unix command line
+        self.TMP_JPG = self.TMP_JPG.replace(":", "_")
         self.execute_at_exit()
 
     def split_filepath(self, filepath):

--- a/server_ipup.py
+++ b/server_ipup.py
@@ -41,7 +41,8 @@ def ip_replace(filename: str):
         content = file.read()
     ip_ad = ip_getter()
     # Replace the string
-    new_content = re.sub(r'\b10.1.12.\w*\b', ip_ad, content)
+    new_content = re.sub(r'\b10\.1\.(?:[0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.'
+                         r'(?:[0-9]{1,2}|1[0-9]{2}|2[0-4][0-9]|25[0-5])\b', ip_ad, content)
 
     # Open the file in write mode
     with open(filename, 'w') as file:


### PR DESCRIPTION
small change on line 50 of importer: the semicolon errors out the command line in mac os but works fine in ubuntu.