### PR TITLE
allows for verified count of removals

### DIFF
--- a/ichthyology_importer.py
+++ b/ichthyology_importer.py
@@ -8,8 +8,6 @@ from monitoring_tools import MonitoringTools
 from time_utils import get_pst_time_now_string
 from datetime import datetime
 
-starting_time_stamp = datetime.now()
-
 logging.basicConfig(level=logging.DEBUG)
 
 
@@ -45,7 +43,6 @@ class IchthyologyImporter(Importer):
         if not self.full_import and ich_importer_config.MAILING_LIST:
             image_dict = self.image_client.imported_files
             self.image_client.monitoring_tools.send_monitoring_report(subject=f"ICH_Batch:{get_pst_time_now_string()}",
-                                                                      time_stamp=starting_time_stamp,
                                                                       image_dict=image_dict)
 
     def get_catalog_number(self, filename):

--- a/image_client.py
+++ b/image_client.py
@@ -291,7 +291,7 @@ class ImageClient:
 
             if self.config.MAILING_LIST:
                 self.monitoring_tools.append_monitoring_dict(self.imported_files, id,
-                                                            original_path, False, self.monitoring_tools.logger)
+                                                             original_path, self.monitoring_tools.logger)
 
             raise UploadFailureException
         else:
@@ -310,7 +310,7 @@ class ImageClient:
             logging.info("adding to image")
             if self.config.MAILING_LIST:
                 self.monitoring_tools.append_monitoring_dict(self.imported_files, id,
-                                                            original_path, True, self.monitoring_tools.logger)
+                                                             original_path, self.monitoring_tools.logger)
 
         self.logger.debug("Upload to file server complete")
 
@@ -380,8 +380,8 @@ class ImageClient:
 
         assert False
 
-    def send_report(self, subject_prefix, time_stamp):
+    def send_report(self, subject_prefix):
         subject = f"{subject_prefix}: SUCCESS REPORT"
-        self.monitoring_tools.send_monitoring_report(subject, time_stamp, image_dict=self.imported_files)
+        self.monitoring_tools.send_monitoring_report(subject, image_dict=self.imported_files)
         subject = f"{subject_prefix}: REMOVED FILES REPORT"
-        self.monitoring_tools.send_monitoring_report(subject, time_stamp, image_dict=self.removed_files, remove=True)
+        self.monitoring_tools.send_monitoring_report(subject, image_dict=self.removed_files, remove=True)

--- a/iz_importer.py
+++ b/iz_importer.py
@@ -62,12 +62,10 @@ class IzImporter(Importer):
         self.directory_tree_core = DirectoryTree(IZ_SCAN_FOLDERS, pickle_for_debug=False)
         self.directory_tree_core.process_files(self.build_filename_map)
         print("Starting to process loaded core files...")
-        time_stamp = get_pst_time_now_string()
         self.process_loaded_files()
 
         if self.iz_importer_config.MAILING_LIST:
-            self.image_client.send_report(subject_prefix=f"IZ_BATCH",
-                                          time_stamp=time_stamp)
+            self.image_client.send_report(subject_prefix=f"IZ_BATCH")
 
     def _configure_logging(self):
         logging.getLogger('Client.dbutils').setLevel(logging.WARNING)

--- a/monitoring_tools.py
+++ b/monitoring_tools.py
@@ -23,8 +23,6 @@ class MonitoringTools:
             self.check_config_present()
             self.sql_csv_tools = SqlCsvTools(config=self.config, logging_level=self.logger.getEffectiveLevel())
 
-        self.initial_count = self.count_attachments(time_stamp=time_utils.get_pst_time_now_string())
-
 
     def clear_txt(self):
         """clears out the all the contents of a text file , leaving a blank file.
@@ -46,14 +44,13 @@ class MonitoringTools:
         """add_imagepaths_to_html: adds an image path row to the HTML table before the closing </table> tag.
         Args:
             image_dict: dictionary where the key is the image ID and value is a list of tuples
-                        containing image paths and their success status.
+                        containing image paths.
         """
         for key, value in image_dict.items():
             img_id = key
             for result in value:
                 image_path = result[0]
-                success = result[1]
-                monitor_line = f"<tr style='width: 50%'><td>{image_path}</td> <td>{img_id}</td><td>{success}</td></tr>"
+                monitor_line = f"<tr style='width: 50%'><td>{image_path}</td> <td>{img_id}</td></tr>"
 
                 with open(self.path, "r") as file:
                     html_content = file.readlines()
@@ -102,7 +99,7 @@ class MonitoringTools:
                 terms += f"<li>{term}: {value_list[index]}</li>\n"
             return terms
     @staticmethod
-    def append_monitoring_dict(monitoring_dict, unique_id, original_path, success, logger=None):
+    def append_monitoring_dict(monitoring_dict, unique_id, original_path, logger=None):
         """append_monitoring_dict: adds paths to monitoring dictionary,
            allows for multiple original paths to be added per ID without replacement.
         """
@@ -111,12 +108,12 @@ class MonitoringTools:
 
             if not path_exists:
                 # If original_path is not in the list of lists, append the new list
-                monitoring_dict[unique_id].append([original_path, success])
+                monitoring_dict[unique_id].append([original_path])
             if logger:
                 logger.error(f"Attemping to upload {original_path} twice for {unique_id}")
         else:
             # If id does not exist, create a new list of lists
-            monitoring_dict[unique_id] = [[original_path, success]]
+            monitoring_dict[unique_id] = [[original_path]]
 
     def create_html_report(self, report_type: str, section_label: str):
         """
@@ -166,7 +163,6 @@ class MonitoringTools:
               <tr>
                   <th style="width: 50%">File Path</th>
                   <th>ID</th>
-                  <th>Success</th>
               </tr>
           </table>
         </body>
@@ -278,55 +274,11 @@ class MonitoringTools:
         return msg
 
 
-    def count_attachments(self, time_stamp):
-        """function to count # of attachments at init, to get a simple metric of the database state
-        args:
-            time_stamp: used to count attachments added only before this timestamp.
-            """
-        sql = """SELECT COUNT(AttachmentID) 
-                            FROM attachment
-                            WHERE TimestampCreated <= %s ;
-               """
-
-        params = (str(time_stamp),)
-
-        count = self.sql_csv_tools.get_record(sql=sql, params=params)
-
-        return count
-
-
-    def verify_image_db_changes(self, time_stamp, initial_count=None, remove=False):
-        """verify_image_db_changes: final sql check to verify the actual image database state change.
-            args:
-                time_stamp: used to count attachments added only before/after this timestamp upper/lower bound.
-                initial_count: used with removals, the pre-change count of images to compare the difference.
-                remove: True if counting removals.
-            """
-
-        if remove:
-
-            final_count = self.count_attachments(time_stamp=time_stamp)
-
-            batch_size = int(final_count) - int(initial_count)
-        else:
-            sql = """SELECT COUNT(AttachmentID)
-                            FROM attachment
-                            WHERE TimestampCreated >= %s 
-                            AND CreatedByAgentID = %s ;"""
-
-            params = (f'{str(time_stamp)}', f'{self.AGENT_ID}')
-
-            batch_size = self.sql_csv_tools.get_record(sql=sql, params=params)
-
-        return batch_size
-
-
-    def send_monitoring_report(self, subject, time_stamp, image_dict: dict, value_list=None, remove=False):
-        """send_monitoring_report: completes the final steps after adding batch failure/success rates.
+    def send_monitoring_report(self, subject, image_dict: dict, value_list=None, remove=False):
+        """send_monitoring_report: completes the final steps after adding batch image paths to table.
                                     attaches custom graphs and images before sending email through smtp
             args:
                 subject: subject line of report email
-                time_stamp: the starting timestamp for upload
                 image_dict: the dictionary of paths added/removed.
                 value_list: list of values for summary stats table. optional
                 remove: boolean. whether to report removals.
@@ -340,8 +292,7 @@ class MonitoringTools:
 
         self.add_summary_statistics(value_list)
 
-        batch_size = self.verify_image_db_changes(time_stamp=time_stamp, remove=remove,
-                                                  initial_count=self.initial_count)
+        batch_size = len(image_dict)
 
         if batch_size is None:
             self.logger.warning("batch_size is None. If not true, check configured AgentID")

--- a/monitoring_tools_derived.py
+++ b/monitoring_tools_derived.py
@@ -1,80 +1,66 @@
 from monitoring_tools import MonitoringTools
 import time_utils
+import os
 class MonitoringToolsDir(MonitoringTools):
     def __init__(self, batch_md5, config, report_path, active):
         self.batch_md5 = batch_md5
         MonitoringTools.__init__(self, config=config, report_path=report_path, active=active)
 
-    def add_format_batch_report(self, custom_terms=None):
-        """add_format_batch_report:
-            creates template of upload batch report. Takes standard summary terms and args,
-           and allows for custom terms to be added with custom_terms.
-           args:
-                num_records: the number of records uploaded to DB
-                uploader: agent id , or name of uploader.
-                md5_code: the md5 code of this current upload batch.
-                config: the config file to use.
-                custom_terms: the list of custom values to add as summary terms, myst correspond with order of
-                              SUMMARY_TERMS variable in config."""
 
-        if custom_terms is None:
-            custom_terms = ""
+    def create_html_report(self, report_type: str, section_label: str):
+        """
+        Creates an HTML batch report (upload/remove) with standard structure.
+        Args:
+            report_type: The report type string, e.g. "Upload" or "Remove".
+            section_label: Section heading inside the report, e.g. "Images Uploaded" or "Images Removed".
+        """
+        if not os.path.exists(self.path):
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+            open(self.path, 'w').close()
         else:
-            pass
+            self.clear_txt()
 
         report = f"""<html>
         <head>
-            <title>Upload Batch Report:</title>
-            <style>
-            """ + """
-            img {
-                max-width: 300px; /* Maximum width of 300 pixels */
-                max-height: 300px; /* Maximum height of 200 pixels */
-            }
-                    table {
+        <title>{report_type} Batch Report</title>
+        <style>
+            img {{
+                max-width: 300px;
+                max-height: 300px;
+            }}
+            table {{
                 table-layout: fixed;
                 border-collapse: collapse;
                 width: 100%;
-            }
-
-            table, th, td {
+            }}
+            table, th, td {{
                 border: 1px solid black;
-            }
-
-            th, td {
+            }}
+            th, td {{
                 padding: 8px;
                 white-space: nowrap;
                 overflow: hidden;
                 text-align: left;
-            }
+            }}
         </style>
         </head>
-        """ + f"""<body>
-            <h1>Upload Batch Report</h1>
-            <hr>
-            <p>Date and Time: {time_utils.get_pst_time_now_string()}</p>
-            <p>Batch MD5: {self.batch_md5}</p>
-            <p>Uploader: {self.config.AGENT_ID}</p>
-
-            <h2>Summary Statistics:</h2>
-            <ul>
-                {custom_terms}
-            </ul>
-            <h2>Summary Figures:</h2>
-            <h2>Images Uploaded:</h2>
-            <table>
-                <tr>
-                    <th style="width: 50%">File Path</th>
-                    <th>ID</th>
-                    <th>Success</th>
-                </tr>
-
-            </table>
-
+        <body>
+          <h1>{report_type} Batch Report</h1>
+          <hr>
+          <p>Date and Time: {time_utils.get_pst_time_now_string()}</p>
+          <p>Batch MD5: {self.batch_md5}</p>
+          <p>Uploader: {self.AGENT_ID}</p>
+    
+          <h2>{section_label}:</h2>
+          <table>
+              <tr>
+                  <th style="width: 50%">File Path</th>
+                  <th>ID</th>
+                  <th>Success</th>
+              </tr>
+          </table>
         </body>
         </html>
         """
 
         self.add_line_between(line_num=0, string=report)
-
-

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -1108,7 +1108,7 @@ class PicturaeImporter(Importer):
             image_dict = self.botany_importer.image_client.imported_files
             value_list = [len(self.new_taxa)]
             self.image_client.monitoring_tools.send_monitoring_report(subject=f"PIC_Batch{time_utils.get_pst_time_now_string()}",
-                                                     time_stamp=starting_time_stamp, image_dict=image_dict,
-                                                     value_list=value_list)
+                                                                      image_dict=image_dict,
+                                                                      value_list=value_list)
 
         self.logger.info("process finished")

--- a/tests/iz_importer_tests/test_build_filename_map_utils.py
+++ b/tests/iz_importer_tests/test_build_filename_map_utils.py
@@ -402,7 +402,7 @@ class TestIzImporterBuildFilenameMapUtils(TestIzImporterBase):
                                                         self.assertEqual(status, FILENAME_BUILD_STATUS.REMOVED_FILE)
                                                         self.assertFalse(success)
                                                         # Verify monitoring_dict was updated
-                                                        expected_dict = {12345: [[full_path, True]]}
+                                                        expected_dict = {12345: [[full_path]]}
                                                         self.assertEqual(self.importer.image_client.removed_files, expected_dict)
                                                         self.assertNotIn(full_path, self.importer.image_client.imported_files)
                                                         mock_remove_file_from_database.return_value = True


### PR DESCRIPTION
removes sql verified check of attachments table after batch removal/import instead relies on the dict produced by the image client. Time stamp param removed from monitoring tools, now creates the timestamp at time of sending.