### PR TITLE
removal of sql db check from monitoring tools.

### DIFF
--- a/botany_importer.py
+++ b/botany_importer.py
@@ -1,7 +1,6 @@
 
 from importer import Importer
 import time_utils
-from datetime import datetime
 import os
 import re
 import logging
@@ -18,7 +17,6 @@ from time_utils import get_pst_time_now_string
 # I:\botany\TYPE IMAGES\CAS_Batch13
 # CAS0410512
 # CAS0410512_a
-starting_time_stamp = datetime.now()
 
 class BotanyImporter(Importer):
 
@@ -46,7 +44,6 @@ class BotanyImporter(Importer):
             image_dict = self.image_client.imported_files
             # can add custom stats with param "value_list" if needed
             self.image_client.monitoring_tools.send_monitoring_report(subject=f"BOT_Batch: {get_pst_time_now_string()}",
-                                                                      time_stamp=starting_time_stamp,
                                                                       image_dict=image_dict)
 
 

--- a/ichthyology_importer.py
+++ b/ichthyology_importer.py
@@ -4,11 +4,7 @@ import re
 import logging
 from get_configs import get_config
 from dir_tools import DirTools
-from monitoring_tools import MonitoringTools
 from time_utils import get_pst_time_now_string
-from datetime import datetime
-
-starting_time_stamp = datetime.now()
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -45,7 +41,6 @@ class IchthyologyImporter(Importer):
         if not self.full_import and ich_importer_config.MAILING_LIST:
             image_dict = self.image_client.imported_files
             self.image_client.monitoring_tools.send_monitoring_report(subject=f"ICH_Batch:{get_pst_time_now_string()}",
-                                                                      time_stamp=starting_time_stamp,
                                                                       image_dict=image_dict)
 
     def get_catalog_number(self, filename):

--- a/image_client.py
+++ b/image_client.py
@@ -291,7 +291,7 @@ class ImageClient:
 
             if self.config.MAILING_LIST:
                 self.monitoring_tools.append_monitoring_dict(self.imported_files, id,
-                                                            original_path, False, self.monitoring_tools.logger)
+                                                             original_path, self.monitoring_tools.logger)
 
             raise UploadFailureException
         else:
@@ -310,7 +310,7 @@ class ImageClient:
             logging.info("adding to image")
             if self.config.MAILING_LIST:
                 self.monitoring_tools.append_monitoring_dict(self.imported_files, id,
-                                                            original_path, True, self.monitoring_tools.logger)
+                                                             original_path, self.monitoring_tools.logger)
 
         self.logger.debug("Upload to file server complete")
 
@@ -380,8 +380,8 @@ class ImageClient:
 
         assert False
 
-    def send_report(self, subject_prefix, time_stamp):
+    def send_report(self, subject_prefix):
         subject = f"{subject_prefix}: SUCCESS REPORT"
-        self.monitoring_tools.send_monitoring_report(subject, time_stamp, image_dict=self.imported_files)
+        self.monitoring_tools.send_monitoring_report(subject, image_dict=self.imported_files)
         subject = f"{subject_prefix}: REMOVED FILES REPORT"
-        self.monitoring_tools.send_monitoring_report(subject, time_stamp, image_dict=self.removed_files, remove=True)
+        self.monitoring_tools.send_monitoring_report(subject, image_dict=self.removed_files, remove=True)

--- a/iz_importer.py
+++ b/iz_importer.py
@@ -9,7 +9,6 @@ from importer import Importer
 from directory_tree import DirectoryTree
 from cas_metadata_tools import MetadataTools, EXIFConstants, BaseConstants
 
-from time_utils import get_pst_time_now_string
 from get_configs import get_config
 from specify_constants import SpecifyConstants
 
@@ -62,12 +61,10 @@ class IzImporter(Importer):
         self.directory_tree_core = DirectoryTree(IZ_SCAN_FOLDERS, pickle_for_debug=False)
         self.directory_tree_core.process_files(self.build_filename_map)
         print("Starting to process loaded core files...")
-        time_stamp = get_pst_time_now_string()
         self.process_loaded_files()
 
         if self.iz_importer_config.MAILING_LIST:
-            self.image_client.send_report(subject_prefix=f"IZ_BATCH",
-                                          time_stamp=time_stamp)
+            self.image_client.send_report(subject_prefix=f"IZ_BATCH")
 
     def _configure_logging(self):
         logging.getLogger('Client.dbutils').setLevel(logging.WARNING)

--- a/monitoring_tools_derived.py
+++ b/monitoring_tools_derived.py
@@ -1,80 +1,66 @@
 from monitoring_tools import MonitoringTools
 import time_utils
+import os
 class MonitoringToolsDir(MonitoringTools):
     def __init__(self, batch_md5, config, report_path, active):
         self.batch_md5 = batch_md5
         MonitoringTools.__init__(self, config=config, report_path=report_path, active=active)
 
-    def add_format_batch_report(self, custom_terms=None):
-        """add_format_batch_report:
-            creates template of upload batch report. Takes standard summary terms and args,
-           and allows for custom terms to be added with custom_terms.
-           args:
-                num_records: the number of records uploaded to DB
-                uploader: agent id , or name of uploader.
-                md5_code: the md5 code of this current upload batch.
-                config: the config file to use.
-                custom_terms: the list of custom values to add as summary terms, myst correspond with order of
-                              SUMMARY_TERMS variable in config."""
 
-        if custom_terms is None:
-            custom_terms = ""
+    def create_html_report(self, report_type: str, section_label: str):
+        """
+        Creates an HTML batch report (upload/remove) with standard structure.
+        Args:
+            report_type: The report type string, e.g. "Upload" or "Remove".
+            section_label: Section heading inside the report, e.g. "Images Uploaded" or "Images Removed".
+        """
+        if not os.path.exists(self.path):
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+            open(self.path, 'w').close()
         else:
-            pass
+            self.clear_txt()
 
         report = f"""<html>
         <head>
-            <title>Upload Batch Report:</title>
-            <style>
-            """ + """
-            img {
-                max-width: 300px; /* Maximum width of 300 pixels */
-                max-height: 300px; /* Maximum height of 200 pixels */
-            }
-                    table {
+        <title>{report_type} Batch Report</title>
+        <style>
+            img {{
+                max-width: 300px;
+                max-height: 300px;
+            }}
+            table {{
                 table-layout: fixed;
                 border-collapse: collapse;
                 width: 100%;
-            }
-
-            table, th, td {
+            }}
+            table, th, td {{
                 border: 1px solid black;
-            }
-
-            th, td {
+            }}
+            th, td {{
                 padding: 8px;
                 white-space: nowrap;
                 overflow: hidden;
                 text-align: left;
-            }
+            }}
         </style>
         </head>
-        """ + f"""<body>
-            <h1>Upload Batch Report</h1>
-            <hr>
-            <p>Date and Time: {time_utils.get_pst_time_now_string()}</p>
-            <p>Batch MD5: {self.batch_md5}</p>
-            <p>Uploader: {self.config.AGENT_ID}</p>
-
-            <h2>Summary Statistics:</h2>
-            <ul>
-                {custom_terms}
-            </ul>
-            <h2>Summary Figures:</h2>
-            <h2>Images Uploaded:</h2>
-            <table>
-                <tr>
-                    <th style="width: 50%">File Path</th>
-                    <th>ID</th>
-                    <th>Success</th>
-                </tr>
-
-            </table>
-
+        <body>
+          <h1>{report_type} Batch Report</h1>
+          <hr>
+          <p>Date and Time: {time_utils.get_pst_time_now_string()}</p>
+          <p>Batch MD5: {self.batch_md5}</p>
+          <p>Uploader: {self.AGENT_ID}</p>
+    
+          <h2>{section_label}:</h2>
+          <table>
+              <tr>
+                  <th style="width: 50%">File Path</th>
+                  <th>ID</th>
+                  <th>Success</th>
+              </tr>
+          </table>
         </body>
         </html>
         """
 
         self.add_line_between(line_num=0, string=report)
-
-

--- a/picturae_importer.py
+++ b/picturae_importer.py
@@ -1108,7 +1108,7 @@ class PicturaeImporter(Importer):
             image_dict = self.botany_importer.image_client.imported_files
             value_list = [len(self.new_taxa)]
             self.image_client.monitoring_tools.send_monitoring_report(subject=f"PIC_Batch{time_utils.get_pst_time_now_string()}",
-                                                     time_stamp=starting_time_stamp, image_dict=image_dict,
-                                                     value_list=value_list)
+                                                                      image_dict=image_dict,
+                                                                      value_list=value_list)
 
         self.logger.info("process finished")

--- a/tests/iz_importer_tests/test_build_filename_map_utils.py
+++ b/tests/iz_importer_tests/test_build_filename_map_utils.py
@@ -402,7 +402,7 @@ class TestIzImporterBuildFilenameMapUtils(TestIzImporterBase):
                                                         self.assertEqual(status, FILENAME_BUILD_STATUS.REMOVED_FILE)
                                                         self.assertFalse(success)
                                                         # Verify monitoring_dict was updated
-                                                        expected_dict = {12345: [[full_path, True]]}
+                                                        expected_dict = {12345: [[full_path]]}
                                                         self.assertEqual(self.importer.image_client.removed_files, expected_dict)
                                                         self.assertNotIn(full_path, self.importer.image_client.imported_files)
                                                         mock_remove_file_from_database.return_value = True


### PR DESCRIPTION
removes sql verified check of attachments table after batch removal/import instead relies on the dict produced by the image client. 
-Time stamp param removed from monitoring tools, now creates the timestamp at time of sending.
-Success /Failure column removed from report and as param, as it is likely redundant.