### PR TITLE
Fix IsPublic lookup bug in importer

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -359,9 +359,9 @@ class Importer:
         try:
             (url, attach_loc) = self.upload_filepath_to_image_database(cur_filepath, redacted=is_redacted, id=id)
 
-            is_redacted_property = attachment_properties_map.get(not SpecifyConstants.ST_IS_PUBLIC, None)
-            if is_redacted_property is not None and is_redacted_property:
-                is_public = False
+            is_public_property = attachment_properties_map.get(SpecifyConstants.ST_IS_PUBLIC, None)
+            if is_public_property is not None:
+                is_public = is_public_property
             else:
                 is_public = not force_redacted
 


### PR DESCRIPTION
## Summary

- **Bug**: `not SpecifyConstants.ST_IS_PUBLIC` evaluates to `not "ispublic"` → `False`, so `attachment_properties_map.get(False, None)` always returns `None`. Lines 362-364 were dead code — the `is_public` value was never read from the properties map.
- **Fix**: Use the correct key (`SpecifyConstants.ST_IS_PUBLIC`) to read `IsPublic` directly from the properties map. Fall back to `not force_redacted` only when the property is absent.
- **Impact**: The bug accidentally produced correct results for the IZ importer because the fallback `is_public = not force_redacted` equals the original key.csv value (the caller passes `force_redacted = not is_public`). With this fix, the code now correctly reads the property for all callers rather than relying on the roundtrip through the fallback path.

## Test plan

- [ ] Run existing IZ importer tests (`tests/iz_importer_tests/`)
- [ ] Verify IsPublic=FALSE key.csv directories still produce `IsPublic=0` in Specify attachment records
- [ ] Verify IsPublic=TRUE key.csv directories still produce `IsPublic=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)