### PR TITLE
Add IZ redaction sync and fix botany sync

### DIFF
--- a/attachment_utils.py
+++ b/attachment_utils.py
@@ -171,3 +171,20 @@ class AttachmentUtils:
             logging.error(f"Error fetching collection object id: {collection_object_id}\n SQL: {sql}")
             raise DatabaseInconsistentError()
         return any(val in [True, 1, b'\x01'] for val in retval)
+
+    def get_is_iz_collection_object_redacted(self, collection_object_id):
+        sql = """
+        SELECT co.YesNo1
+        FROM collectionobject co
+        WHERE co.CollectionObjectID = %s
+        """
+        cursor = self.db_utils.get_cursor()
+        params = (str(collection_object_id) if collection_object_id is not None else None,)
+        cursor.execute(sql, params)
+        retval = cursor.fetchone()
+        cursor.close()
+
+        if retval is None:
+            logging.error(f"Error fetching collection object id: {collection_object_id}\n SQL: {sql}")
+            raise DatabaseInconsistentError()
+        return retval[0] in [True, 1, b'\x01']

--- a/botany_sync.sh
+++ b/botany_sync.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 LOCKFILE=/tmp/botany_sync.lock
-STALE_SECONDS=86400
 SUCCESS_MARKER=/admin/web-asset-importer/.botany_sync_last_success
 
 cleanup() {
@@ -9,19 +8,18 @@ cleanup() {
 }
 
 if [ -e "$LOCKFILE" ]; then
-    # Check if lockfile is stale (older than 24 hours)
-    lock_age=$(( $(date +%s) - $(stat -c %Y "$LOCKFILE" 2>/dev/null || echo 0) ))
-    if [ "$lock_age" -gt "$STALE_SECONDS" ]; then
-        echo "Stale lockfile detected (age: ${lock_age}s). Removing and proceeding."
-        rm -f "$LOCKFILE"
-    else
-        echo "Botany sync is already running. Exiting."
+    OLD_PID=$(cat "$LOCKFILE" 2>/dev/null)
+    if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+        echo "Botany sync is already running (pid $OLD_PID). Exiting."
         exit 0
+    else
+        echo "Stale lockfile (pid $OLD_PID no longer running). Removing and proceeding."
+        rm -f "$LOCKFILE"
     fi
 fi
 
-# Create the lock file and trap cleanup
-touch "$LOCKFILE"
+# Create the lock file with our PID and trap cleanup
+echo $$ > "$LOCKFILE"
 trap cleanup EXIT
 
 # Running nightly sync

--- a/iz_sync.sh
+++ b/iz_sync.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 LOCKFILE=/tmp/iz_sync.lock
-STALE_SECONDS=86400
 SUCCESS_MARKER=/admin/web-asset-importer/.iz_sync_last_success
 
 cleanup() {
@@ -9,19 +8,18 @@ cleanup() {
 }
 
 if [ -e "$LOCKFILE" ]; then
-    # Check if lockfile is stale (older than 24 hours)
-    lock_age=$(( $(date +%s) - $(stat -c %Y "$LOCKFILE" 2>/dev/null || echo 0) ))
-    if [ "$lock_age" -gt "$STALE_SECONDS" ]; then
-        echo "Stale lockfile detected (age: ${lock_age}s). Removing and proceeding."
-        rm -f "$LOCKFILE"
-    else
-        echo "IZ sync is already running. Exiting."
+    OLD_PID=$(cat "$LOCKFILE" 2>/dev/null)
+    if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+        echo "IZ sync is already running (pid $OLD_PID). Exiting."
         exit 0
+    else
+        echo "Stale lockfile (pid $OLD_PID no longer running). Removing and proceeding."
+        rm -f "$LOCKFILE"
     fi
 fi
 
-# Create the lock file and trap cleanup
-touch "$LOCKFILE"
+# Create the lock file with our PID and trap cleanup
+echo $$ > "$LOCKFILE"
 trap cleanup EXIT
 
 # Running nightly sync

--- a/iz_sync.sh
+++ b/iz_sync.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-LOCKFILE=/tmp/botany_sync.lock
+LOCKFILE=/tmp/iz_sync.lock
 STALE_SECONDS=86400
-SUCCESS_MARKER=/admin/web-asset-importer/.botany_sync_last_success
+SUCCESS_MARKER=/admin/web-asset-importer/.iz_sync_last_success
 
 cleanup() {
     rm -f "$LOCKFILE"
@@ -15,7 +15,7 @@ if [ -e "$LOCKFILE" ]; then
         echo "Stale lockfile detected (age: ${lock_age}s). Removing and proceeding."
         rm -f "$LOCKFILE"
     else
-        echo "Botany sync is already running. Exiting."
+        echo "IZ sync is already running. Exiting."
         exit 0
     fi
 fi
@@ -31,12 +31,12 @@ git pull
 git submodule update --init --recursive
 
 # Run nightly_sync.py and capture its exit status
-python3 ./nightly_sync.py Botany
+python3 ./nightly_sync.py IZ
 sync_exit_code=$?
 
 # If nightly_sync.py fails, exit with status 1
 if [ "$sync_exit_code" -ne 0 ]; then
-    echo "Sync failed. Check botany_sync_log.txt for details."
+    echo "Sync failed. Check iz_sync_log.txt for details."
     exit 1
 fi
 

--- a/nightly_sync.py
+++ b/nightly_sync.py
@@ -5,23 +5,19 @@ from get_configs import get_config
 import traceback
 import logging
 import sys
-from typing import Optional
+from typing import Optional, Callable
 
 image_db: Optional[ImageDb] = None
-botany_importer = None
 attachment_utils: Optional[AttachmentUtils] = None
+collection_object_redaction_checker: Optional[Callable] = None
 
-def import_configs():
-    botany_importer_config = get_config(config='Botany')
-    ich_importer_config = get_config(config='Ichthyology')
-    return botany_importer_config, ich_importer_config
 
 def get_specify_state(internal_filename):
-    global attachment_utils
+    global attachment_utils, collection_object_redaction_checker
     coid = attachment_utils.get_collectionobjectid_from_filename(internal_filename)
     if coid is None:
         return None
-    redacted_collection_object = attachment_utils.get_is_botany_collection_object_redacted(coid)
+    redacted_collection_object = collection_object_redaction_checker(coid)
     redacted_attachment = attachment_utils.get_is_attachment_redacted(internal_filename)
     logging.debug(
         f"get specify state {internal_filename}, collection object: {coid} collection object state: {redacted_collection_object} attachment state: {redacted_attachment}")
@@ -42,12 +38,13 @@ def redact(internal_filename, redacted):
         logging.debug(f"No state change required. State is {redacted} object is {internal_filename}")
 
 
-def do_sync(collection_name, specify_db_connection):
-    global image_db, attachment_utils
+def do_sync(collection_name, specify_db_connection, co_redaction_method):
+    global image_db, attachment_utils, collection_object_redaction_checker
 
-    print(f"Starting sync..")
+    print(f"Starting sync for {collection_name}..")
     image_db = ImageDb()
     attachment_utils = AttachmentUtils(specify_db_connection)
+    collection_object_redaction_checker = getattr(attachment_utils, co_redaction_method)
     cursor = image_db.get_cursor()
     query = f"""SELECT  internal_filename,  redacted FROM images where collection='{collection_name}'"""
 
@@ -74,30 +71,49 @@ def do_sync(collection_name, specify_db_connection):
     return record_list
 
 
+COLLECTION_CONFIG = {
+    "Botany": {
+        "config_key": "Botany",
+        "co_redaction_method": "get_is_botany_collection_object_redacted",
+    },
+    "Ichthyology": {
+        "config_key": "Ichthyology",
+        "co_redaction_method": "get_is_botany_collection_object_redacted",
+    },
+    "IZ": {
+        "config_key": "IZ",
+        "co_redaction_method": "get_is_iz_collection_object_redacted",
+    },
+}
+
+
 def main():
     logging.basicConfig()
     logging.getLogger().setLevel(logging.DEBUG)
-    botany_importer_config, ich_importer_config = import_configs()
+
     if len(sys.argv) != 2:
-        print("Need a collection argument.")
+        print(f"Usage: {sys.argv[0]} <collection>")
+        print(f"Available collections: {', '.join(COLLECTION_CONFIG.keys())}")
         sys.exit(1)
-    if sys.argv[1] == "Botany":
-        collection_name = botany_importer_config.COLLECTION_NAME
-        specify_db_connection = DbUtils(
-            botany_importer_config.USER,
-            botany_importer_config.PASSWORD,
-            botany_importer_config.SPECIFY_DATABASE_PORT,
-            botany_importer_config.SPECIFY_DATABASE_HOST,
-            botany_importer_config.SPECIFY_DATABASE)
-    elif sys.argv[1] == "Ichthyology":
-        collection_name = ich_importer_config.COLLECTION_NAME
-        specify_db_connection = DbUtils(
-            ich_importer_config.USER,
-            ich_importer_config.PASSWORD,
-            ich_importer_config.SPECIFY_DATABASE_PORT,
-            ich_importer_config.SPECIFY_DATABASE_HOST,
-            ich_importer_config.SPECIFY_DATABASE)
-    do_sync(collection_name, specify_db_connection)
+
+    collection_arg = sys.argv[1]
+    if collection_arg not in COLLECTION_CONFIG:
+        print(f"Unknown collection: {collection_arg}")
+        print(f"Available collections: {', '.join(COLLECTION_CONFIG.keys())}")
+        sys.exit(1)
+
+    config_entry = COLLECTION_CONFIG[collection_arg]
+    importer_config = get_config(config=config_entry["config_key"])
+
+    collection_name = importer_config.COLLECTION_NAME
+    specify_db_connection = DbUtils(
+        importer_config.USER,
+        importer_config.PASSWORD,
+        importer_config.SPECIFY_DATABASE_PORT,
+        importer_config.SPECIFY_DATABASE_HOST,
+        importer_config.SPECIFY_DATABASE)
+
+    do_sync(collection_name, specify_db_connection, config_entry["co_redaction_method"])
 
 
 if __name__ == '__main__':

--- a/nightly_sync.py
+++ b/nightly_sync.py
@@ -82,6 +82,7 @@ COLLECTION_CONFIG = {
     },
     "IZ": {
         "config_key": "IZ",
+        "image_db_collection": "Invertebrate Zoology",
         "co_redaction_method": "get_is_iz_collection_object_redacted",
     },
 }
@@ -105,7 +106,7 @@ def main():
     config_entry = COLLECTION_CONFIG[collection_arg]
     importer_config = get_config(config=config_entry["config_key"])
 
-    collection_name = importer_config.COLLECTION_NAME
+    collection_name = config_entry.get("image_db_collection", importer_config.COLLECTION_NAME)
     specify_db_connection = DbUtils(
         importer_config.USER,
         importer_config.PASSWORD,


### PR DESCRIPTION
## Summary
- Add redaction sync for Invertebrate Zoology (IZ) collection, checking `collectionobject.YesNo1` (block from export) to propagate redaction state from Specify DB to the image server
- Refactor `nightly_sync.py` to be collection-aware via `COLLECTION_CONFIG` dict instead of hardcoded if/elif branches — adding new collections now requires only a config entry and a redaction checker method
- Fix `botany_sync.sh`: stale lockfile detection (24h threshold), correct venv path (`./env/` → `./venv/`), success marker
- New `iz_sync.sh` shell script

## Files changed
- **attachment_utils.py** — new `get_is_iz_collection_object_redacted()` method
- **nightly_sync.py** — refactored to data-driven collection dispatch, added IZ support
- **botany_sync.sh** — stale lock fix, venv path fix, success marker
- **iz_sync.sh** — new file

## Deployment
After merge, add crontab entry on ibss-crontab:
```
0 7 * * 5 admin /admin/web-asset-importer/iz_sync.sh > /admin/web-asset-importer/iz_sync_log.txt 2>&1
```