### PR TITLE
Fix ICH redaction sync: wrong method + infinite retry

### DIFF
--- a/attachment_utils.py
+++ b/attachment_utils.py
@@ -188,3 +188,22 @@ class AttachmentUtils:
             logging.error(f"Error fetching collection object id: {collection_object_id}\n SQL: {sql}")
             raise DatabaseInconsistentError()
         return retval[0] in [True, 1, b'\x01']
+
+    def get_is_ich_collection_object_redacted(self, collection_object_id):
+        sql = """
+        SELECT co.YesNo1, vt.MS_Name, d.YesNo1
+        FROM collectionobject co
+        LEFT JOIN determination d ON co.CollectionObjectID = d.CollectionObjectID AND d.IsCurrent = 1
+        LEFT JOIN vtaxon vt ON d.TaxonID = vt.taxonid
+        WHERE co.CollectionObjectID = %s
+        """
+        cursor = self.db_utils.get_cursor()
+        params = (str(collection_object_id) if collection_object_id is not None else None,)
+        cursor.execute(sql, params)
+        retval = cursor.fetchone()
+        cursor.close()
+
+        if retval is None:
+            logging.error(f"Error fetching collection object id: {collection_object_id}\n SQL: {sql}")
+            raise DatabaseInconsistentError()
+        return any(val in [True, 1, b'\x01'] for val in retval if val is not None)

--- a/nightly_sync.py
+++ b/nightly_sync.py
@@ -67,6 +67,7 @@ def do_sync(collection_name, specify_db_connection, co_redaction_method):
             except Exception as e:
                 print(f"Error, probably sql: \"{e}\"", file=sys.stderr, flush=True)
                 print(f"exception type: {type(e).__name__}", file=sys.stderr, flush=True)
+                next_record = True
 
     return record_list
 
@@ -78,7 +79,7 @@ COLLECTION_CONFIG = {
     },
     "Ichthyology": {
         "config_key": "Ichthyology",
-        "co_redaction_method": "get_is_botany_collection_object_redacted",
+        "co_redaction_method": "get_is_ich_collection_object_redacted",
     },
     "IZ": {
         "config_key": "IZ",


### PR DESCRIPTION
## Summary
- The Ichthyology nightly sync was calling `get_is_botany_collection_object_redacted`, which queries `casbotany` tables with `casich` IDs — always returning NULL, raising `DatabaseInconsistentError`, and retrying the same record forever (generated 63GB of log per run)
- Adds `get_is_ich_collection_object_redacted` matching the `vich_ipt` IPT view logic: checks `co.YesNo1`, `vt.MS_Name`, and `d.YesNo1`
- Points Ichthyology config at the new method
- Fixes infinite retry by setting `next_record = True` in the generic `except` block

## Root cause
`COLLECTION_CONFIG` in `nightly_sync.py` mapped Ichthyology to the botany redaction method. That method hardcodes `casbotany.*` table references, so it always fails when connected to `casich`. The ICH redaction sync has never successfully processed a single record.

## How redaction was verified
The `vich_ipt` view on ibss-specify-dbs defines what ICH considers redacted for GBIF/IPT export:
```sql
WHERE (co.YesNo1 IS NULL OR co.YesNo1 = 0)
  AND (vt.MS_Name = 0 OR vt.MS_Name IS NULL)
  AND (d.YesNo1 = 0 OR d.YesNo1 IS NULL)
```
The new method mirrors this logic exactly.

## Test plan
- [ ] Verify the nightly sync runs tonight without infinite loop
- [ ] Check `/admin/nightly_sync_ich.log` is a reasonable size after the run
- [ ] Spot-check a few ICH images in the `images` DB to confirm redaction state updates